### PR TITLE
docs: add multi-chip backend support info to features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A high-performance distributed quantum statevector simulator built on PyTorch, e
 ## ✨ Features
 
 - **Distributed Statevector Simulation**: Leverage multiple GPUs to simulate large quantum circuits using `DTensor` from `torch.distributed`
-- **Multi-backend Support**: NVIDIA CUDA, Hygon DCU, Moore Threads MUSA
+- **Multi-Chip Backend Support**: NVIDIA CUDA, Hygon DCU, Moore Threads MUSA
 - **Automatic Resharding**: Intelligently redistributes statevectors to minimize communication overhead during gate operations
 - **Comprehensive Gate Set**: Includes Pauli, Clifford, rotation, and controlled gates with parameterized support
 - **Invertible Backpropagation**: Memory-efficient gradient computation for trainable quantum circuits

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A high-performance distributed quantum statevector simulator built on PyTorch, e
 ## ✨ Features
 
 - **Distributed Statevector Simulation**: Leverage multiple GPUs to simulate large quantum circuits using `DTensor` from `torch.distributed`
+- **Multi-backend Support**: NVIDIA CUDA, Hygon DCU, Moore Threads MUSA
 - **Automatic Resharding**: Intelligently redistributes statevectors to minimize communication overhead during gate operations
 - **Comprehensive Gate Set**: Includes Pauli, Clifford, rotation, and controlled gates with parameterized support
 - **Invertible Backpropagation**: Memory-efficient gradient computation for trainable quantum circuits


### PR DESCRIPTION
## Description

Add supported AI chip backends to the Features section for better visibility.

## Changes

- Added "Multi-Chip Backend Support" line in Features section
- Lists NVIDIA CUDA, Hygon DCU, and Moore Threads MUSA

## Related

This is a documentation improvement, no code changes.