### PR TITLE
docs: clarify QSteed plugin installation for Quafu

### DIFF
--- a/docs/guides/COMPILER_PLUGINS.md
+++ b/docs/guides/COMPILER_PLUGINS.md
@@ -5,6 +5,10 @@ main repository owns the `CircuitIR` boundary and plugin lifecycle; the plugin
 owns its compiler dependency and translation code. Installing a plugin does not
 import or activate it during `import flagquantum`.
 
+For QSteed installation and an offline compilation check, follow the
+[Quafu setup guide](QUAFU_BACKEND.md#install-the-compiler-plugin). The plugin
+is maintained in [FlagQuantum-Compiler-QSteed](https://github.com/FlagQuantum/FlagQuantum-Compiler-QSteed).
+
 ## Package registration
 
 A package such as `flagquantum-compiler-qsteed` registers one zero-argument

--- a/docs/guides/QUAFU_BACKEND.md
+++ b/docs/guides/QUAFU_BACKEND.md
@@ -3,6 +3,43 @@
 FlagQuantum talks directly to the HTTP contract implemented by
 `quafusqc.Task`; installing `quafusqc` is not required.
 
+## Install the compiler plugin
+
+The Quafu examples use the independently maintained
+[FlagQuantum Compiler QSteed](https://github.com/FlagQuantum/FlagQuantum-Compiler-QSteed)
+plugin. Installing FlagQuantum alone, or its `quafu` extra, does not install
+this compiler plugin. The `quafu` extra supplies the optional calibration reader.
+
+Use Python 3.12 for the verified setup below. From a FlagQuantum 0.2 checkout:
+
+```bash
+python -m pip install -e .
+python -m pip install "qsteed @ git+https://github.com/BAQIS-Quantum/qsteed.git@46584efde731aea9eec27b5466919b76fe5f3184"
+python -m pip install flagquantum-compiler-qsteed==0.1.0
+```
+
+The plugin requires FlagQuantum `>=0.2,<0.3` and QSteed
+`0.2.3+quafu.sqc`. Install the pinned upstream build before the plugin;
+PyPI QSteed `0.2.2` is not a supported substitute. The plugin itself is
+[published on PyPI](https://pypi.org/project/flagquantum-compiler-qsteed/0.1.0/).
+
+FlagQuantum discovers the installed `compiler.qsteed` entry point automatically.
+Verify installation without provider credentials or a hardware submission:
+
+```python
+import flagquantum as fq
+
+circuit = fq.Circuit(2).h(0).cx(0, 1)
+compiled = fq.compile(circuit, compiler="qsteed")
+print(compiled.instructions)
+```
+
+This checks offline compilation only. Selecting `target="quafu:Baihua"` also
+requires access to the selected chip's calibration; executing `fq.run` with
+that target submits a real task.
+
+## Configure and run
+
 Create a local `.env` file without putting the token in source code:
 
 ```bash


### PR DESCRIPTION
The Quafu guide previously ran examples with `compiler="qsteed"` without explaining how to install that plugin. Add the verified installation order for FlagQuantum 0.2, the pinned upstream QSteed build, and the published compiler plugin. Clarify that the `quafu` extra supplies the calibration reader, and link the plugin repository and PyPI release.

Include an offline compilation example before credential configuration and distinguish it from a live Quafu submission. Link the setup from the compiler-plugin guide.

Validation: documentation consistency check passed; the new offline example passed with the installed plugin wheel and pinned QSteed build. No hardware job was submitted.
