### PR TITLE
feat: provide CUDA and QSteed development containers

### DIFF
--- a/.github/workflows/publish-dev-container.yml
+++ b/.github/workflows/publish-dev-container.yml
@@ -1,11 +1,17 @@
-name: Publish private development container
+name: Publish development containers
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - docker/dev/**
+      - compose.dev.yaml
+      - pyproject.toml
+      - .github/workflows/publish-dev-container.yml
   push:
     branches: [main]
     paths:
-      - docker/dev/Dockerfile
+      - docker/dev/**
       - compose.dev.yaml
       - pyproject.toml
       - flagquantum/**
@@ -16,9 +22,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish-cpu:
+  publish:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: cpu
+            platforms: linux/amd64,linux/arm64
+            extras: dev,jax,viz,examples,interop-all
+            torch-index: https://download.pytorch.org/whl/cpu
+            jax-spec: jax>=0.10,<0.11
+          - variant: cuda-amd64
+            platforms: linux/amd64
+            extras: dev,jax,viz,examples,interop-all,cuda
+            torch-index: https://download.pytorch.org/whl/cu128
+            jax-spec: jax[cuda12]>=0.10,<0.11
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write
@@ -37,6 +57,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -49,43 +70,31 @@ jobs:
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |
-            type=raw,value=cpu
-            type=sha,prefix=cpu-sha-,format=short
+            type=raw,value=${{ matrix.variant }}
+            type=sha,prefix=${{ matrix.variant }}-sha-,format=short
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.flagquantum.image.class=development_only
             org.flagquantum.sc27.release_evidence=false
 
-      - name: Build and publish CPU image
+      - name: Build and publish ${{ matrix.variant }} image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/dev/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platforms }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BASE_IMAGE=python:3.12-slim-bookworm
-            EXTRAS=dev,jax
-            TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
+            EXTRAS=${{ matrix.extras }}
+            TORCH_INDEX_URL=${{ matrix.torch-index }}
+            JAX_SPEC=${{ matrix.jax-spec }}
             SOURCE_URL=https://github.com/${{ github.repository }}
             SOURCE_REVISION=${{ github.sha }}
-          cache-from: type=gha,scope=flagquantum-dev-cpu
-          cache-to: type=gha,mode=max,scope=flagquantum-dev-cpu
+          cache-from: type=gha,scope=flagquantum-dev-${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=flagquantum-dev-${{ matrix.variant }}
           provenance: mode=max
           sbom: true
-
-      - name: Fail if the GHCR package is not private
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GHCR_OWNER_TYPE: ${{ github.event.repository.owner.type }}
-        shell: bash
-        run: |
-          owner_scope="users"
-          if [ "$GHCR_OWNER_TYPE" = "Organization" ]; then
-            owner_scope="orgs"
-          fi
-          visibility="$(gh api "/${owner_scope}/${GITHUB_REPOSITORY_OWNER}/packages/container/flagquantum-dev" --jq .visibility)"
-          test "$visibility" = private

--- a/.github/workflows/publish-dev-container.yml
+++ b/.github/workflows/publish-dev-container.yml
@@ -28,15 +28,27 @@ jobs:
       matrix:
         include:
           - variant: cpu
+            target: full
             platforms: linux/amd64,linux/arm64
             extras: dev,jax,viz,examples,interop-all
             torch-index: https://download.pytorch.org/whl/cpu
             jax-spec: jax>=0.10,<0.11
           - variant: cuda-amd64
+            target: full
             platforms: linux/amd64
             extras: dev,jax,viz,examples,interop-all,cuda
             torch-index: https://download.pytorch.org/whl/cu128
             jax-spec: jax[cuda12]>=0.10,<0.11
+          - variant: cpu-no-jax
+            target: no-jax
+            platforms: linux/amd64,linux/arm64
+            extras: dev,viz,examples,quafu
+            torch-index: https://download.pytorch.org/whl/cpu
+          - variant: cuda-amd64-no-jax
+            target: no-jax
+            platforms: linux/amd64
+            extras: dev,viz,examples,quafu,cuda
+            torch-index: https://download.pytorch.org/whl/cu128
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -83,6 +95,7 @@ jobs:
         with:
           context: .
           file: docker/dev/Dockerfile
+          target: ${{ matrix.target }}
           platforms: ${{ matrix.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-dev-container.yml
+++ b/.github/workflows/publish-dev-container.yml
@@ -108,6 +108,7 @@ jobs:
             SOURCE_URL=https://github.com/${{ github.repository }}
             SOURCE_REVISION=${{ github.sha }}
           cache-from: type=gha,scope=flagquantum-dev-${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=flagquantum-dev-${{ matrix.variant }}
+          # PRs validate the image without uploading multi-GB CUDA caches.
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=gha,mode=max,scope=flagquantum-dev-{0}', matrix.variant) || '' }}
           provenance: mode=max
           sbom: true

--- a/.github/workflows/publish-dev-container.yml
+++ b/.github/workflows/publish-dev-container.yml
@@ -29,7 +29,7 @@ jobs:
         include:
           - variant: cpu
             target: full
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
             extras: dev,jax,viz,examples,interop-all
             torch-index: https://download.pytorch.org/whl/cpu
             jax-spec: jax>=0.10,<0.11
@@ -41,7 +41,7 @@ jobs:
             jax-spec: jax[cuda12]>=0.10,<0.11
           - variant: cpu-no-jax
             target: no-jax
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
             extras: dev,viz,examples,quafu
             torch-index: https://download.pytorch.org/whl/cpu
           - variant: cuda-amd64-no-jax

--- a/README.md
+++ b/README.md
@@ -20,18 +20,21 @@ distributed training, device modeling, and fault-tolerant quantum computing rese
 - **Connect simulation to hardware.** Keep the circuit and requested observable
   explicit as you move between supported execution targets.
 
-This is a pre-release framework. Local training and selected distributed paths
-have correctness evidence; support is specific to each backend and workload.
+Support is specific to each backend and workload. Local training and selected
+distributed paths have correctness evidence.
 See the [validation scope](docs/reference/PUBLICATION_VALIDATION.md) for what has
 been tested and what remains a research goal.
 
 ## Train your first quantum model
 
-Requires Python **3.10–3.12**. From the repository root:
+Requires Python **3.10–3.12**:
 
 ```console
-python -m pip install -e .
+python -m pip install flagquantum
 ```
+
+To build a CPU or GPU environment with QSteed and optional JAX, follow the
+[container guide](docker/dev/README.md).
 
 Build a two-qubit circuit and learn its rotation angle by minimizing ⟨Z₀⟩. `fq.Module` exposes the quantum model to PyTorch; `outputs` selects what
 to measure after training.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,18 @@ been tested and what remains a research goal.
 
 ## Train your first quantum model
 
-Requires Python **3.10–3.12**:
+Requires Python **3.10–3.12**. Install the released version:
 
 ```console
 python -m pip install flagquantum
+```
+
+Or install the development version from source (editable, with development tools):
+
+```console
+git clone https://github.com/flagos-ai/FlagQuantum.git
+cd FlagQuantum
+python -m pip install -e ".[dev]"
 ```
 
 To build a CPU or GPU environment with QSteed and optional JAX, follow the

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,4 +1,5 @@
 x-flagquantum-dev: &flagquantum-dev
+  platform: linux/amd64
   image: ${FLAGQUANTUM_DEV_IMAGE:-flagquantum-dev:local}
   build: &dev-build
     context: .

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -3,6 +3,7 @@ x-flagquantum-dev: &flagquantum-dev
   build: &dev-build
     context: .
     dockerfile: docker/dev/Dockerfile
+    target: full
     args: &dev-build-args
       BASE_IMAGE: ${FLAGQUANTUM_BASE_IMAGE:-python:3.12-slim-bookworm}
       EXTRAS: ${FLAGQUANTUM_DEV_EXTRAS:-dev,jax,viz,examples,interop-all}
@@ -37,6 +38,36 @@ services:
     platform: linux/amd64
     profiles: [gpu]
     gpus: all
+    environment:
+      PYTHONPATH: /workspace
+      PYTHONUNBUFFERED: "1"
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
+
+  dev-no-jax:
+    <<: *flagquantum-dev
+    image: ${FLAGQUANTUM_NO_JAX_DEV_IMAGE:-flagquantum-dev:cpu-no-jax-local}
+    profiles: [cpu-no-jax]
+    build:
+      <<: *dev-build
+      target: no-jax
+      args:
+        <<: *dev-build-args
+        EXTRAS: dev,viz,examples,quafu
+
+  dev-gpu-no-jax:
+    <<: *flagquantum-dev
+    image: ${FLAGQUANTUM_GPU_NO_JAX_DEV_IMAGE:-flagquantum-dev:cuda-no-jax-local}
+    profiles: [gpu-no-jax]
+    platform: linux/amd64
+    gpus: all
+    build:
+      <<: *dev-build
+      target: no-jax
+      args:
+        <<: *dev-build-args
+        EXTRAS: dev,viz,examples,quafu,cuda
+        TORCH_INDEX_URL: https://download.pytorch.org/whl/cu128
     environment:
       PYTHONPATH: /workspace
       PYTHONUNBUFFERED: "1"

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,13 +1,13 @@
 x-flagquantum-dev: &flagquantum-dev
   image: ${FLAGQUANTUM_DEV_IMAGE:-flagquantum-dev:local}
-  build:
+  build: &dev-build
     context: .
     dockerfile: docker/dev/Dockerfile
-    args:
+    args: &dev-build-args
       BASE_IMAGE: ${FLAGQUANTUM_BASE_IMAGE:-python:3.12-slim-bookworm}
-      EXTRAS: ${FLAGQUANTUM_DEV_EXTRAS:-dev,jax}
+      EXTRAS: ${FLAGQUANTUM_DEV_EXTRAS:-dev,jax,viz,examples,interop-all}
       TORCH_INDEX_URL: ${FLAGQUANTUM_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
-      SOURCE_URL: ${FLAGQUANTUM_SOURCE_URL:-https://github.com/FlagQuantum/FlagQuantum}
+      SOURCE_URL: ${FLAGQUANTUM_SOURCE_URL:-https://github.com/flagos-ai/FlagQuantum}
       SOURCE_REVISION: ${FLAGQUANTUM_SOURCE_REVISION:-development}
   working_dir: /workspace
   volumes:
@@ -26,6 +26,15 @@ services:
 
   dev-gpu:
     <<: *flagquantum-dev
+    image: ${FLAGQUANTUM_GPU_DEV_IMAGE:-flagquantum-dev:cuda-local}
+    build:
+      <<: *dev-build
+      args:
+        <<: *dev-build-args
+        EXTRAS: dev,jax,viz,examples,interop-all,cuda
+        TORCH_INDEX_URL: https://download.pytorch.org/whl/cu128
+        JAX_SPEC: jax[cuda12]>=0.10,<0.11
+    platform: linux/amd64
     profiles: [gpu]
     gpus: all
     environment:

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -37,7 +37,10 @@ COPY . /opt/FlagQuantum
 WORKDIR /opt/FlagQuantum
 
 RUN python -m pip install --upgrade pip setuptools wheel \
-    && python -m pip install "torch==${TORCH_VERSION}" --index-url "${TORCH_INDEX_URL}"
+    && python -m pip install "torch==${TORCH_VERSION}" --index-url "${TORCH_INDEX_URL}" \
+    && python -m pip install "jupyterlab>=4,<5" "ipykernel>=6,<8" \
+    && python -m ipykernel install --sys-prefix --name python3 --display-name "FlagQuantum" \
+    && jupyter lab --version
 
 ENV PYTHONPATH=/workspace
 ENTRYPOINT ["/usr/bin/tini", "--"]
@@ -49,7 +52,8 @@ ARG EXTRAS=dev,viz,examples,quafu
 RUN python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" -e ".[${EXTRAS}]" -r docker/dev/requirements-qsteed.txt \
     && python -m pip check \
     && python -c "import importlib.util; assert importlib.util.find_spec('jax') is None; assert importlib.util.find_spec('jaxlib') is None" \
-    && python docker/dev/smoke.py --qsteed
+    && python docker/dev/smoke.py --qsteed \
+    && python docker/dev/check_notebook.py --qsteed
 WORKDIR /workspace
 
 FROM base AS full
@@ -57,16 +61,19 @@ ARG EXTRAS=dev,jax,viz,examples,interop-all
 ARG JAX_SPEC=jax>=0.10,<0.11
 RUN python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" "${JAX_SPEC}" -e ".[${EXTRAS}]" \
     && python -m pip check \
-    && JAX_PLATFORMS=cpu python docker/dev/smoke.py
+    && JAX_PLATFORMS=cpu python docker/dev/smoke.py \
+    && python docker/dev/check_notebook.py
 
 # QSteed/pyquafu require NumPy 1.x, while JAX requires NumPy 2.x.
 # Keep the compiler in an isolated environment; never bypass dependency checks.
 RUN python -m venv /opt/qsteed \
     && /opt/qsteed/bin/python -m pip install --upgrade pip setuptools wheel \
     && /opt/qsteed/bin/python -m pip install "torch==${TORCH_VERSION}" --index-url https://download.pytorch.org/whl/cpu \
-    && /opt/qsteed/bin/python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" -e ".[quafu]" -r docker/dev/requirements-qsteed.txt \
+    && /opt/qsteed/bin/python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" -e ".[quafu]" -r docker/dev/requirements-qsteed.txt "ipykernel>=6,<8" \
     && /opt/qsteed/bin/python -m pip check \
     && /opt/qsteed/bin/python docker/dev/smoke.py --qsteed \
+    && /opt/qsteed/bin/python -m ipykernel install --prefix=/usr/local --name flagquantum-qsteed --display-name "FlagQuantum (QSteed)" \
+    && python docker/dev/check_notebook.py --kernel flagquantum-qsteed --qsteed \
     && install -m 755 docker/dev/flagquantum-qsteed-python /usr/local/bin/flagquantum-qsteed-python
 
 ENV XLA_PYTHON_CLIENT_PREALLOCATE=false

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,9 +1,7 @@
 ARG BASE_IMAGE=python:3.12-slim-bookworm
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} AS base
 
-ARG EXTRAS=dev,jax,viz,examples,interop-all
 ARG TORCH_VERSION=2.10.0
-ARG JAX_SPEC=jax>=0.10,<0.11
 ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
 ARG SOURCE_URL=https://github.com/flagos-ai/FlagQuantum
 ARG SOURCE_REVISION=development
@@ -11,7 +9,7 @@ ARG SOURCE_REVISION=development
 LABEL org.opencontainers.image.source="${SOURCE_URL}" \
       org.opencontainers.image.revision="${SOURCE_REVISION}" \
       org.opencontainers.image.title="FlagQuantum development environment" \
-      org.opencontainers.image.description="FlagQuantum development environment with JAX, QSteed and ecosystem tools" \
+      org.opencontainers.image.description="FlagQuantum development environment with PyTorch and QSteed" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.flagquantum.image.class="development_only" \
       org.flagquantum.sc27.release_evidence="false"
@@ -39,8 +37,25 @@ COPY . /opt/FlagQuantum
 WORKDIR /opt/FlagQuantum
 
 RUN python -m pip install --upgrade pip setuptools wheel \
-    && python -m pip install "torch==${TORCH_VERSION}" --index-url "${TORCH_INDEX_URL}" \
-    && python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" "${JAX_SPEC}" -e ".[${EXTRAS}]" \
+    && python -m pip install "torch==${TORCH_VERSION}" --index-url "${TORCH_INDEX_URL}"
+
+ENV PYTHONPATH=/workspace
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["bash"]
+
+# A single environment for training and compilation when JAX is not needed.
+FROM base AS no-jax
+ARG EXTRAS=dev,viz,examples,quafu
+RUN python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" -e ".[${EXTRAS}]" -r docker/dev/requirements-qsteed.txt \
+    && python -m pip check \
+    && python -c "import importlib.util; assert importlib.util.find_spec('jax') is None; assert importlib.util.find_spec('jaxlib') is None" \
+    && python docker/dev/smoke.py --qsteed
+WORKDIR /workspace
+
+FROM base AS full
+ARG EXTRAS=dev,jax,viz,examples,interop-all
+ARG JAX_SPEC=jax>=0.10,<0.11
+RUN python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" "${JAX_SPEC}" -e ".[${EXTRAS}]" \
     && python -m pip check \
     && JAX_PLATFORMS=cpu python docker/dev/smoke.py
 
@@ -55,8 +70,4 @@ RUN python -m venv /opt/qsteed \
     && install -m 755 docker/dev/flagquantum-qsteed-python /usr/local/bin/flagquantum-qsteed-python
 
 ENV XLA_PYTHON_CLIENT_PREALLOCATE=false
-ENV PYTHONPATH=/workspace
 WORKDIR /workspace
-
-ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["bash"]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,15 +1,17 @@
 ARG BASE_IMAGE=python:3.12-slim-bookworm
 FROM ${BASE_IMAGE}
 
-ARG EXTRAS=dev,jax
+ARG EXTRAS=dev,jax,viz,examples,interop-all
+ARG TORCH_VERSION=2.10.0
+ARG JAX_SPEC=jax>=0.10,<0.11
 ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
-ARG SOURCE_URL=https://github.com/FlagQuantum/FlagQuantum
+ARG SOURCE_URL=https://github.com/flagos-ai/FlagQuantum
 ARG SOURCE_REVISION=development
 
 LABEL org.opencontainers.image.source="${SOURCE_URL}" \
       org.opencontainers.image.revision="${SOURCE_REVISION}" \
       org.opencontainers.image.title="FlagQuantum development environment" \
-      org.opencontainers.image.description="Editable CPU and NVIDIA GPU development environment for FlagQuantum" \
+      org.opencontainers.image.description="FlagQuantum development environment with JAX, QSteed and ecosystem tools" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.flagquantum.image.class="development_only" \
       org.flagquantum.sc27.release_evidence="false"
@@ -37,11 +39,22 @@ COPY . /opt/FlagQuantum
 WORKDIR /opt/FlagQuantum
 
 RUN python -m pip install --upgrade pip setuptools wheel \
-    && python -m pip install "torch>=2.5,<2.14" --index-url "${TORCH_INDEX_URL}" \
-    && python -m pip install --no-build-isolation -e ".[${EXTRAS}]" \
+    && python -m pip install "torch==${TORCH_VERSION}" --index-url "${TORCH_INDEX_URL}" \
+    && python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" "${JAX_SPEC}" -e ".[${EXTRAS}]" \
     && python -m pip check \
-    && python -c "import flagquantum as fq; print('FlagQuantum', fq.__version__)"
+    && JAX_PLATFORMS=cpu python docker/dev/smoke.py
 
+# QSteed/pyquafu require NumPy 1.x, while JAX requires NumPy 2.x.
+# Keep the compiler in an isolated environment; never bypass dependency checks.
+RUN python -m venv /opt/qsteed \
+    && /opt/qsteed/bin/python -m pip install --upgrade pip setuptools wheel \
+    && /opt/qsteed/bin/python -m pip install "torch==${TORCH_VERSION}" --index-url https://download.pytorch.org/whl/cpu \
+    && /opt/qsteed/bin/python -m pip install --no-build-isolation "torch==${TORCH_VERSION}" -e ".[quafu]" -r docker/dev/requirements-qsteed.txt \
+    && /opt/qsteed/bin/python -m pip check \
+    && /opt/qsteed/bin/python docker/dev/smoke.py --qsteed \
+    && install -m 755 docker/dev/flagquantum-qsteed-python /usr/local/bin/flagquantum-qsteed-python
+
+ENV XLA_PYTHON_CLIENT_PREALLOCATE=false
 ENV PYTHONPATH=/workspace
 WORKDIR /workspace
 

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -24,6 +24,28 @@ the tested upstream commit in `requirements-qsteed.txt`, followed by the release
 adapter (in `/opt/qsteed` for JAX-enabled variants). The compiler remains independently replaceable through FlagQuantum's
 extension interface. No provider credentials are included.
 
+## JupyterLab
+
+All four variants include JupyterLab 4 and IPython kernels. Launch it from the
+repository root (replace the profile/service for the desired variant):
+
+```bash
+docker compose -f compose.dev.yaml --profile cpu-no-jax run --rm \
+  -p 127.0.0.1:8888:8888 dev-no-jax \
+  jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root
+```
+
+Open the local URL with the token printed in the terminal. The checkout is
+mounted at `/workspace`, so notebooks and edits persist on the host. Token
+authentication remains enabled. On a remote host, access port 8888 through an
+SSH tunnel.
+
+Choose **FlagQuantum** for the main environment. JAX-enabled images also offer
+**FlagQuantum (QSteed)** for the isolated compiler environment. No-JAX images
+support training and QSteed in the main kernel. Each image build launches its
+registered kernels and executes FlagQuantum code; compiler kernels also run
+an offline QSteed compilation.
+
 ## Without JAX
 
 Choose `cpu-no-jax` or `cuda-amd64-no-jax` to train and compile from the same

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -1,6 +1,6 @@
 # Development containers
 
-The main Python environment installs FlagQuantum from the repository checkout,
+The JAX-enabled variants' main Python environment installs FlagQuantum from the repository checkout,
 JAX, plotting and example dependencies, and the Braket, PennyLane, Quafu and
 Qiskit interoperability dependencies. A second environment in the same image
 installs FlagQuantum, QSteed and `flagquantum-compiler-qsteed`.
@@ -9,14 +9,39 @@ installs FlagQuantum, QSteed and `flagquantum-compiler-qsteed`.
 | --- | --- | --- |
 | `cpu` | Linux amd64 / arm64 | CPU PyTorch and JAX |
 | `cuda-amd64` | Linux amd64 | PyTorch CUDA 12.8, JAX CUDA 12 and Triton |
+| `cpu-no-jax` | Linux amd64 / arm64 | CPU PyTorch and QSteed in one environment |
+| `cuda-amd64-no-jax` | Linux amd64 | PyTorch CUDA 12.8, Triton and QSteed in one environment |
 
 The CUDA image includes CPU execution as well. Images install PyTorch 2.10.0;
 other dependency constraints come from `pyproject.toml`. QSteed is installed from
 the tested upstream commit in `requirements-qsteed.txt`, followed by the released
-adapter in `/opt/qsteed`. The compiler remains independently replaceable through FlagQuantum's
+adapter (in `/opt/qsteed` for JAX-enabled variants). The compiler remains independently replaceable through FlagQuantum's
 extension interface. No provider credentials are included.
 
-## Use QSteed
+## Without JAX
+
+Choose `cpu-no-jax` or `cuda-amd64-no-jax` to train and compile from the same
+script using ordinary `python` and `fq.compile(..., compiler="qsteed")`.
+These variants include development tools, plotting, example dependencies and
+Quafu. They omit JAX/JAXlib and the broader `interop-all` extra: its PennyLane
+version also requires NumPy 2, conflicting with QSteed's NumPy 1 requirement.
+No separate compiler environment is needed.
+
+```bash
+docker compose -f compose.dev.yaml --profile gpu-no-jax build dev-gpu-no-jax
+docker compose -f compose.dev.yaml --profile gpu-no-jax run --rm dev-gpu-no-jax \
+  python your_training_and_compilation_script.py
+```
+
+For CPU, use profile `cpu-no-jax` and service `dev-no-jax`. To verify GPU
+execution and QSteed compilation together after publishing:
+
+```bash
+docker run --rm --gpus all ghcr.io/flagos-ai/flagquantum-dev:cuda-amd64-no-jax \
+  python /opt/FlagQuantum/docker/dev/smoke.py --gpu --qsteed
+```
+
+## Use QSteed with JAX-enabled variants
 
 QSteed and pyquafu currently require NumPy < 2, while JAX 0.10 requires NumPy >= 2.
 They cannot share one Python environment. The image isolates the compiler and
@@ -65,7 +90,8 @@ current checkout at `/workspace`.
 
 ## Verify the installed stack
 
-Every image build runs `pip check` in both environments. The main environment
+Every image build runs `pip check` in each installed environment. No-JAX builds
+also assert that neither `jax` nor `jaxlib` is installed and exercise QSteed. The main environment
 tests PyTorch autograd, JAX JIT and FlagQuantum execution; the isolated compiler
 tests PyTorch autograd, FlagQuantum execution and QSteed topology compilation.
 On an NVIDIA host, also run:
@@ -86,5 +112,6 @@ claims. Rebuild when dependencies change. For distributed runs, use the same
 image digest on every node and synchronize any mounted source checkout.
 
 Maintainers can also publish from an authenticated build host with
-`tools/containers/publish_dev_image.sh cpu` or `tools/containers/publish_dev_image.sh cuda`.
+`tools/containers/publish_dev_image.sh cpu` or `tools/containers/publish_dev_image.sh cuda`. Append `-no-jax` to the variant
+argument to publish its single-environment counterpart.
 Keep registry tokens outside source files and Docker build arguments.

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -1,95 +1,90 @@
-# FlagQuantum development container
+# Development containers
 
-This image is for daily editable development and remote GPU testing. It is not
-an SC27 frozen evidence image and must not be used to promote benchmark claims.
+The main Python environment installs FlagQuantum from the repository checkout,
+JAX, plotting and example dependencies, and the Braket, PennyLane, Quafu and
+Qiskit interoperability dependencies. A second environment in the same image
+installs FlagQuantum, QSteed and `flagquantum-compiler-qsteed`.
 
-## Local CPU development
+| Tag | Platform | Numerical stack |
+| --- | --- | --- |
+| `cpu` | Linux amd64 / arm64 | CPU PyTorch and JAX |
+| `cuda-amd64` | Linux amd64 | PyTorch CUDA 12.8, JAX CUDA 12 and Triton |
 
-Build the default Python 3.12 image and run the daily test tier:
+The CUDA image includes CPU execution as well. Images install PyTorch 2.10.0;
+other dependency constraints come from `pyproject.toml`. QSteed is installed from
+the tested upstream commit in `requirements-qsteed.txt`, followed by the released
+adapter in `/opt/qsteed`. The compiler remains independently replaceable through FlagQuantum's
+extension interface. No provider credentials are included.
 
-```bash
-docker compose -f compose.dev.yaml build dev
-docker compose -f compose.dev.yaml run --rm dev \
-  python tools/ci_tier.py pr-default
-```
+## Use QSteed
 
-The default build installs PyTorch from its CPU wheel index, avoiding the
-multi-gigabyte CUDA dependency closure on a non-NVIDIA laptop.
-
-Open an interactive shell with the live checkout mounted at `/workspace`:
-
-```bash
-docker compose -f compose.dev.yaml run --rm dev
-```
-
-## Remote NVIDIA GPU development
-
-The remote host needs the NVIDIA Container Toolkit. Use a CUDA/PyTorch base
-that is already validated on that host; for example, the existing FlagQuantum
-development base can be selected without changing this Dockerfile:
+QSteed and pyquafu currently require NumPy < 2, while JAX 0.10 requires NumPy >= 2.
+They cannot share one Python environment. The image isolates the compiler and
+provides an explicit command:
 
 ```bash
-export FLAGQUANTUM_BASE_IMAGE='tovx/flagquantum@sha256:bce47a929a36ed60a3a199183aead552b8466818839325ac149c28be9f02f2b5'
-export FLAGQUANTUM_DEV_EXTRAS='dev,jax,cuda'
-export FLAGQUANTUM_DEV_IMAGE='flagquantum-dev:cuda-local'
-
-docker compose -f compose.dev.yaml build dev-gpu
-docker compose -f compose.dev.yaml run --rm dev-gpu \
-  python -c 'import torch; print(torch.__version__, torch.cuda.device_count())'
-docker compose -f compose.dev.yaml run --rm dev-gpu \
-  python tools/ci_tier.py gpu-scheduled
+flagquantum-qsteed-python your_compilation_script.py
 ```
 
-The repository is bind-mounted, so code changes do not require an image
-rebuild. Rebuild only when dependencies or the selected base image change.
+Inside that script, use the usual `import flagquantum as fq` and
+`fq.compile(circuit, compiler="qsteed", target=...)`. The main `python` command
+runs the training/JAX environment and does not discover the isolated plugin.
+Transfer trained parameter values or supported circuit artifacts explicitly
+between scripts. The compiler environment uses CPU PyTorch; GPU training runs
+in the main environment. No dependency constraints are overridden.
 
-## Private GHCR publishing
+## Run the GPU image
 
-The GitHub Actions workflow `.github/workflows/publish-dev-container.yml`
-publishes a multi-architecture CPU image on changes to `main`, or when manually
-dispatched:
-
-```text
-ghcr.io/flagquantum/flagquantum-dev:cpu
-ghcr.io/flagquantum/flagquantum-dev:cpu-sha-<commit>
-```
-
-It authenticates with `GITHUB_TOKEN`, attaches OCI provenance and an SBOM, and
-fails if the resulting organization package is not private. The image is
-explicitly labelled `development_only` and cannot serve as SC27 evidence.
-
-The CUDA base is available on the A800 development host rather than a public
-registry, so publish CUDA images from that AMD64 host after logging in to GHCR:
+After the publishing workflow succeeds on `main`:
 
 ```bash
-read -s GHCR_TOKEN
-printf '%s' "$GHCR_TOKEN" | docker login ghcr.io \
-  -u '<github-user>' --password-stdin
-unset GHCR_TOKEN
-
-tools/containers/publish_dev_image.sh cuda
+docker run --rm -it --gpus all --shm-size=8g \
+  ghcr.io/flagos-ai/flagquantum-dev:cuda-amd64
 ```
 
-This publishes both a rolling and immutable tag:
+The host needs a compatible NVIDIA driver and NVIDIA Container Toolkit. The
+image provides CUDA user-space libraries; it does not install the host driver.
+See the [JAX installation requirements](https://docs.jax.dev/en/latest/installation.html)
+and [NVIDIA Container Toolkit guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+JAX memory preallocation is disabled so PyTorch and JAX can share the device.
 
-```text
-ghcr.io/flagquantum/flagquantum-dev:cuda-amd64
-ghcr.io/flagquantum/flagquantum-dev:cuda-<commit>
-```
+For an immutable revision, use the workflow's `cuda-amd64-sha-<commit>` tag or
+image digest. Package visibility is managed separately in GHCR settings; a
+private package still requires authentication.
 
-The login token needs `write:packages` on the publishing host. A test host only
-needs `read:packages` to pull the private image.
-
-## Push once, pull over SSH
-
-After `docker login`, choose a registry path and push the image:
+## Build with a live checkout
 
 ```bash
-export FLAGQUANTUM_DEV_IMAGE='ghcr.io/flagquantum/flagquantum-dev:cuda-amd64'
-docker compose -f compose.dev.yaml build dev-gpu
-docker push "$FLAGQUANTUM_DEV_IMAGE"
+docker compose -f compose.dev.yaml --profile gpu build dev-gpu
+docker compose -f compose.dev.yaml --profile gpu run --rm dev-gpu
 ```
 
-On each remote node, pull the same tag (or preferably its immutable digest),
-keep a synchronized source checkout, and use the `dev-gpu` service. Never put
-registry passwords or tokens in this repository or in Docker build arguments.
+Use `--profile cpu` and `dev` on a CPU machine. The two services use different
+local image tags, so a CPU build cannot replace the GPU image. Both mount the
+current checkout at `/workspace`.
+
+## Verify the installed stack
+
+Every image build runs `pip check` in both environments. The main environment
+tests PyTorch autograd, JAX JIT and FlagQuantum execution; the isolated compiler
+tests PyTorch autograd, FlagQuantum execution and QSteed topology compilation.
+On an NVIDIA host, also run:
+
+```bash
+docker run --rm --gpus all ghcr.io/flagos-ai/flagquantum-dev:cuda-amd64 \
+  python /opt/FlagQuantum/docker/dev/smoke.py --gpu
+```
+
+This command fails if PyTorch or JAX cannot execute on the GPU. Build-time CPU
+checks do not certify GPU correctness or distributed performance. Quantum cloud
+submission still requires separately configured provider access; installing all
+these dependencies does not grant access to a quantum device.
+
+The workflow attaches image provenance and an SBOM. These are development
+images, not frozen research evidence images; they cannot certify benchmark
+claims. Rebuild when dependencies change. For distributed runs, use the same
+image digest on every node and synchronize any mounted source checkout.
+
+Maintainers can also publish from an authenticated build host with
+`tools/containers/publish_dev_image.sh cpu` or `tools/containers/publish_dev_image.sh cuda`.
+Keep registry tokens outside source files and Docker build arguments.

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -7,10 +7,16 @@ installs FlagQuantum, QSteed and `flagquantum-compiler-qsteed`.
 
 | Tag | Platform | Numerical stack |
 | --- | --- | --- |
-| `cpu` | Linux amd64 / arm64 | CPU PyTorch and JAX |
+| `cpu` | Linux amd64 | CPU PyTorch and JAX |
 | `cuda-amd64` | Linux amd64 | PyTorch CUDA 12.8, JAX CUDA 12 and Triton |
-| `cpu-no-jax` | Linux amd64 / arm64 | CPU PyTorch and QSteed in one environment |
+| `cpu-no-jax` | Linux amd64 | CPU PyTorch and QSteed in one environment |
 | `cuda-amd64-no-jax` | Linux amd64 | PyTorch CUDA 12.8, Triton and QSteed in one environment |
+
+All four images target Linux AMD64. The pinned Quafu/QSteed dependencies do
+not provide the required Linux ARM64 distributions, so these images do not
+claim native ARM64 support. On Apple Silicon, CPU images require AMD64
+emulation (`--platform linux/amd64`); GPU images require an NVIDIA Linux host.
+Compose selects AMD64 explicitly for every variant.
 
 The CUDA image includes CPU execution as well. Images install PyTorch 2.10.0;
 other dependency constraints come from `pyproject.toml`. QSteed is installed from

--- a/docker/dev/check_notebook.py
+++ b/docker/dev/check_notebook.py
@@ -1,0 +1,32 @@
+"""Check that a registered notebook kernel can execute the installed framework."""
+
+import argparse
+
+from jupyter_client import KernelManager
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kernel", default="python3")
+    parser.add_argument("--qsteed", action="store_true")
+    args = parser.parse_args()
+    manager = KernelManager(kernel_name=args.kernel)
+    manager.start_kernel()
+    client = manager.blocking_client()
+    try:
+        client.start_channels()
+        client.wait_for_ready(timeout=60)
+        code = "import flagquantum as fq\nc = fq.Circuit(2).h(0).cx(0, 1)\nresult = fq.run(c)"
+        if args.qsteed:
+            code += '\ncompiled = fq.compile(c, compiler="qsteed")\nassert compiled.instructions'
+        reply = client.execute_interactive(code, timeout=120)
+        if reply["content"]["status"] != "ok":
+            raise RuntimeError(f"Notebook kernel failed: {reply['content']}")
+        print(f"Notebook kernel passed: {args.kernel}, qsteed={args.qsteed}")
+    finally:
+        client.stop_channels()
+        manager.shutdown_kernel(now=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/dev/flagquantum-qsteed-python
+++ b/docker/dev/flagquantum-qsteed-python
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /opt/qsteed/bin/python "$@"

--- a/docker/dev/requirements-qsteed.txt
+++ b/docker/dev/requirements-qsteed.txt
@@ -1,0 +1,3 @@
+# Upstream fixes required by the compiler adapter; see the plugin installation guide.
+qsteed @ git+https://github.com/BAQIS-Quantum/qsteed.git@46584efde731aea9eec27b5466919b76fe5f3184
+flagquantum-compiler-qsteed==0.1.1

--- a/docker/dev/smoke.py
+++ b/docker/dev/smoke.py
@@ -15,11 +15,9 @@ def main() -> None:
         "--gpu", action="store_true", help="Require real CUDA execution"
     )
     parser.add_argument(
-        "--qsteed", action="store_true", help="Test the isolated compiler environment"
+        "--qsteed", action="store_true", help="Test QSteed instead of JAX"
     )
     args = parser.parse_args()
-    if args.qsteed and args.gpu:
-        parser.error("The isolated compiler environment uses CPU PyTorch")
     device = "cuda" if args.gpu else "cpu"
     if args.gpu and not torch.cuda.is_available():
         raise RuntimeError("PyTorch cannot access a CUDA device")

--- a/docker/dev/smoke.py
+++ b/docker/dev/smoke.py
@@ -1,0 +1,57 @@
+"""Exercise the installed development stack without provider credentials."""
+
+import argparse
+from importlib.metadata import version
+
+import numpy as np
+import torch
+
+import flagquantum as fq
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--gpu", action="store_true", help="Require real CUDA execution"
+    )
+    parser.add_argument(
+        "--qsteed", action="store_true", help="Test the isolated compiler environment"
+    )
+    args = parser.parse_args()
+    if args.qsteed and args.gpu:
+        parser.error("The isolated compiler environment uses CPU PyTorch")
+    device = "cuda" if args.gpu else "cpu"
+    if args.gpu and not torch.cuda.is_available():
+        raise RuntimeError("PyTorch cannot access a CUDA device")
+    if not args.qsteed:
+        import jax
+        import jax.numpy as jnp
+
+        jax_device = jax.devices("gpu" if args.gpu else "cpu")[0]
+        with jax.default_device(jax_device):
+            np.testing.assert_allclose(jax.jit(lambda x: x @ x)(jnp.eye(2)), np.eye(2))
+        print(f"JAX executed on {jax_device.platform}")
+    x = torch.tensor([2.0], device=device, requires_grad=True)
+    x.square().sum().backward()
+    torch.testing.assert_close(x.grad, torch.tensor([4.0], device=device))
+    circuit = fq.Circuit(3).h(0).cx(0, 2)
+    if args.qsteed:
+        compiled = fq.compile(
+            circuit,
+            compiler="qsteed",
+            target={
+                "basis_gates": ("h", "x", "rx", "ry", "rz", "cx"),
+                "coupling_map": ((0, 1), (1, 2)),
+            },
+        )
+        if not compiled.instructions:
+            raise RuntimeError("QSteed returned an empty circuit")
+    fq.run(circuit)
+    packages = ("qsteed", "flagquantum-compiler-qsteed") if args.qsteed else ("jax",)
+    for package in ("flagquantum", "torch", *packages):
+        print(f"{package}={version(package)}")
+    print(f"Development stack smoke passed: torch={device}, qsteed={args.qsteed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_dev_container_distribution.py
+++ b/tests/unit/test_dev_container_distribution.py
@@ -14,20 +14,19 @@ def test_development_image_is_fail_closed_for_sc27_evidence() -> None:
     assert "org.opencontainers.image.source" in dockerfile
 
 
-def test_ghcr_workflow_publishes_private_multiarch_cpu_tags() -> None:
+def test_ghcr_workflow_publishes_cpu_and_cuda_variants() -> None:
     workflow = (ROOT / ".github/workflows/publish-dev-container.yml").read_text(
         encoding="utf-8"
     )
 
     assert "packages: write" in workflow
     assert "linux/amd64,linux/arm64" in workflow
-    assert "type=raw,value=cpu" in workflow
-    assert "type=sha,prefix=cpu-sha-" in workflow
-    assert "github.event.repository.owner.type" in workflow
-    assert 'owner_scope="users"' in workflow
-    assert 'owner_scope="orgs"' in workflow
-    assert '"/${owner_scope}/${GITHUB_REPOSITORY_OWNER}/packages/container/' in workflow
-    assert 'test "$visibility" = private' in workflow
+    assert "variant: cpu" in workflow
+    assert "variant: cuda-amd64" in workflow
+    assert "https://download.pytorch.org/whl/cu128" in workflow
+    assert "jax[cuda12]>=0.10,<0.11" in workflow
+    assert "type=raw,value=${{ matrix.variant }}" in workflow
+    assert "type=sha,prefix=${{ matrix.variant }}-sha-" in workflow
     assert "provenance: mode=max" in workflow
     assert "sbom: true" in workflow
 

--- a/tests/unit/test_dev_container_distribution.py
+++ b/tests/unit/test_dev_container_distribution.py
@@ -21,6 +21,9 @@ def test_ghcr_workflow_publishes_cpu_and_cuda_variants() -> None:
 
     assert "packages: write" in workflow
     assert "linux/amd64,linux/arm64" in workflow
+    assert "variant: cpu-no-jax" in workflow
+    assert "variant: cuda-amd64-no-jax" in workflow
+    assert "target: no-jax" in workflow
     assert "variant: cpu" in workflow
     assert "variant: cuda-amd64" in workflow
     assert "https://download.pytorch.org/whl/cu128" in workflow
@@ -38,5 +41,5 @@ def test_remote_publisher_keeps_cuda_and_cpu_namespaces_separate() -> None:
 
     assert 'current_tag="$image:cuda-amd64"' in publisher
     assert 'version_tag="$image:cuda-$version"' in publisher
-    assert '--tag "$image:cpu"' in publisher
-    assert '--tag "$image:cpu-$version"' in publisher
+    assert '--tag "$image:cpu${suffix}"' in publisher
+    assert '--tag "$image:cpu${suffix}-$version"' in publisher

--- a/tests/unit/test_dev_container_distribution.py
+++ b/tests/unit/test_dev_container_distribution.py
@@ -20,7 +20,8 @@ def test_ghcr_workflow_publishes_cpu_and_cuda_variants() -> None:
     )
 
     assert "packages: write" in workflow
-    assert "linux/amd64,linux/arm64" in workflow
+    assert "platforms: linux/amd64" in workflow
+    assert "linux/arm64" not in workflow
     assert "variant: cpu-no-jax" in workflow
     assert "variant: cuda-amd64-no-jax" in workflow
     assert "target: no-jax" in workflow

--- a/tools/containers/publish_dev_image.sh
+++ b/tools/containers/publish_dev_image.sh
@@ -21,7 +21,7 @@ case "$variant" in
     ;;
 esac
 
-owner="${GHCR_OWNER:-flagquantum}"
+owner="${GHCR_OWNER:-flagos-ai}"
 owner="$(printf '%s' "$owner" | tr '[:upper:]' '[:lower:]')"
 image="${GHCR_IMAGE:-ghcr.io/${owner}/flagquantum-dev}"
 
@@ -46,7 +46,7 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
-source_url="https://github.com/FlagQuantum/FlagQuantum"
+source_url="https://github.com/flagos-ai/FlagQuantum"
 
 case "$variant" in
   cpu)
@@ -54,7 +54,7 @@ case "$variant" in
       --platform linux/amd64,linux/arm64 \
       --file docker/dev/Dockerfile \
       --build-arg BASE_IMAGE=python:3.12-slim-bookworm \
-      --build-arg EXTRAS=dev,jax \
+      --build-arg EXTRAS=dev,jax,viz,examples,interop-all \
       --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu \
       --build-arg SOURCE_URL="$source_url" \
       --build-arg SOURCE_REVISION="$version" \
@@ -66,7 +66,7 @@ case "$variant" in
       .
     ;;
   cuda)
-    base_image="${FLAGQUANTUM_BASE_IMAGE:-tovx/flagquantum@sha256:bce47a929a36ed60a3a199183aead552b8466818839325ac149c28be9f02f2b5}"
+    base_image="${FLAGQUANTUM_BASE_IMAGE:-python:3.12-slim-bookworm}"
     version_tag="$image:cuda-$version"
     current_tag="$image:cuda-amd64"
 
@@ -74,8 +74,9 @@ case "$variant" in
       --platform linux/amd64 \
       --file docker/dev/Dockerfile \
       --build-arg BASE_IMAGE="$base_image" \
-      --build-arg EXTRAS=dev,jax,cuda \
-      --build-arg TORCH_INDEX_URL=https://pypi.org/simple \
+      --build-arg EXTRAS=dev,jax,viz,examples,interop-all,cuda \
+      --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128 \
+      --build-arg 'JAX_SPEC=jax[cuda12]>=0.10,<0.11' \
       --build-arg SOURCE_URL="$source_url" \
       --build-arg SOURCE_REVISION="$version" \
       --tag "$version_tag" \

--- a/tools/containers/publish_dev_image.sh
+++ b/tools/containers/publish_dev_image.sh
@@ -60,7 +60,7 @@ fi
 case "$variant" in
   cpu)
     docker buildx build \
-      --platform linux/amd64,linux/arm64 \
+      --platform linux/amd64 \
       --file docker/dev/Dockerfile \
       --target "$target" \
       --build-arg BASE_IMAGE=python:3.12-slim-bookworm \

--- a/tools/containers/publish_dev_image.sh
+++ b/tools/containers/publish_dev_image.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: $0 <cpu|cuda> [version]" >&2
+  echo "usage: $0 <cpu|cuda|cpu-no-jax|cuda-no-jax> [version]" >&2
   echo "environment: GHCR_OWNER, GHCR_IMAGE, FLAGQUANTUM_BASE_IMAGE" >&2
 }
 
@@ -14,7 +14,7 @@ fi
 variant="$1"
 
 case "$variant" in
-  cpu | cuda) ;;
+  cpu | cuda | cpu-no-jax | cuda-no-jax) ;;
   *)
     usage
     exit 2
@@ -47,19 +47,29 @@ if ! docker info >/dev/null 2>&1; then
 fi
 
 source_url="https://github.com/flagos-ai/FlagQuantum"
+target=full
+extras=dev,jax,viz,examples,interop-all
+suffix=""
+if [[ "$variant" == *-no-jax ]]; then
+  target=no-jax
+  extras=dev,viz,examples,quafu
+  suffix=-no-jax
+  variant="${variant%-no-jax}"
+fi
 
 case "$variant" in
   cpu)
     docker buildx build \
       --platform linux/amd64,linux/arm64 \
       --file docker/dev/Dockerfile \
+      --target "$target" \
       --build-arg BASE_IMAGE=python:3.12-slim-bookworm \
-      --build-arg EXTRAS=dev,jax,viz,examples,interop-all \
+      --build-arg EXTRAS="$extras" \
       --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu \
       --build-arg SOURCE_URL="$source_url" \
       --build-arg SOURCE_REVISION="$version" \
-      --tag "$image:cpu" \
-      --tag "$image:cpu-$version" \
+      --tag "$image:cpu${suffix}" \
+      --tag "$image:cpu${suffix}-$version" \
       --provenance=mode=max \
       --sbom=true \
       --push \
@@ -69,12 +79,17 @@ case "$variant" in
     base_image="${FLAGQUANTUM_BASE_IMAGE:-python:3.12-slim-bookworm}"
     version_tag="$image:cuda-$version"
     current_tag="$image:cuda-amd64"
+    if [[ -n "$suffix" ]]; then
+      version_tag="$image:cuda${suffix}-$version"
+      current_tag="$image:cuda-amd64${suffix}"
+    fi
 
     docker build \
       --platform linux/amd64 \
       --file docker/dev/Dockerfile \
+      --target "$target" \
       --build-arg BASE_IMAGE="$base_image" \
-      --build-arg EXTRAS=dev,jax,viz,examples,interop-all,cuda \
+      --build-arg EXTRAS="$extras,cuda" \
       --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128 \
       --build-arg 'JAX_SPEC=jax[cuda12]>=0.10,<0.11' \
       --build-arg SOURCE_URL="$source_url" \


### PR DESCRIPTION
## Change

Provide CPU and CUDA development images with JAX, example/visualization dependencies and the supported ecosystem extras. The CUDA variant installs PyTorch 2.10.0 from the CUDA 12.8 wheel index and JAX CUDA 12 support. Compose uses distinct CPU/GPU images and GPU build arguments.

For JAX-enabled variants, include QSteed and compiler adapter 0.1.1 in an isolated `/opt/qsteed` environment, invoked with `flagquantum-qsteed-python`. QSteed/pyquafu require NumPy < 2, whereas JAX 0.10 requires NumPy >= 2; installing them in the same Python environment is not supported. The main training environment does not discover the isolated plugin.

Add `cpu-no-jax` and `cuda-amd64-no-jax` variants using the Dockerfile's `no-jax` target. These install PyTorch and QSteed in the same environment, so training and `fq.compile(..., compiler="qsteed")` can use ordinary Python in one script. They exclude JAX/JAXlib and the broader interoperability extra (PennyLane also requires NumPy 2). Build-time checks reject accidentally installed JAX/JAXlib. Compose and the manual publishing script expose both variants.

All four variants target Linux AMD64: the pinned Quafu/QSteed dependencies do not provide compatible Linux ARM64 distributions. Compose selects AMD64 explicitly, including on Apple Silicon through emulation.

Build all four variants on relevant PRs without publishing. Publish tags on main/manual runs with provenance and SBOM. Remove the private-only package assertion; GHCR visibility remains an explicit package setting. Each build runs pip check and numerical/compiler smoke checks in the appropriate environments.

All variants include JupyterLab 4 and ipykernel. JAX-enabled images register a separate QSteed kernel. Build-time checks start each registered kernel and execute FlagQuantum code, including offline compilation in compiler kernels. The guide provides a loopback-bound launch command with token authentication. PR builds do not upload large CUDA caches; publication runs retain cache exports.

## Validation

- Smoke/unit suite: 1,943 passed, 12 skipped; two Git-dependent checks initially failed because the system Git was unavailable. Both passed on the focused rerun using the configured fallback Git (10 tests passed).
- Three container configuration tests passed. Compose CPU/GPU configurations rendered correctly; shell syntax and diff checks passed.
- Main JAX/FlagQuantum smoke and isolated QSteed compilation smoke passed in existing local test environments using PyTorch 2.13.0. These are script checks, not validation of the image's pinned PyTorch 2.10.0 environment.
- Full image builds and real CUDA execution still require validation. The A800 host could not reach Docker Hub directly; a transferred base image resolved that pull, but the initial build was stopped after identifying the NumPy conflict. No GPU correctness claim is made yet.


- Latest local smoke/unit suite: 1,945 passed, 12 skipped. ARM64 dependency failures in the first container CI were diagnosed and the declared image platforms corrected to AMD64; full image validation is rerunning.


- Jupyter main and isolated QSteed kernels passed actual local startup/execution checks; the latest local smoke/unit suite passed 1,945 tests with 12 skipped. Full image CI is rerunning with JupyterLab.
