### PR TITLE
feat: submit Quafu circuits for service-side compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For a complete classical–quantum model, follow the
 
 The experimental adapters can evaluate the same observable on a Jiuding GPU
 workspace or Quafu quantum hardware. Configure the [Jiuding workspace and credentials](docs/guides/JIUDING.md)
-or the [Quafu token and QSteed plugin](docs/guides/QUAFU_BACKEND.md) before
+or the [Quafu token](docs/guides/QUAFU_BACKEND.md) before
 running the corresponding call.
 
 ```python
@@ -86,12 +86,15 @@ jiuding_result = fq.run(
     trained_circuit, target="jiuding:gpu", outputs=measurement,
 )
 
-# Quantum hardware: compile, submit, and estimate from measured shots
+# Quantum hardware: service compilation and estimation from measured shots
 quafu_result = fq.run(
-    trained_circuit, target="quafu:Baihua", compiler="qsteed",
+    trained_circuit, target="quafu:Baihua",
     outputs=measurement, shots=1024,
 )
 ```
+
+Direct Quafu submission requires the development version containing this feature.
+With the published 0.2.0 release, use the documented local QSteed compilation path.
 
 Jiuding computes a simulated expectation; Quafu estimates it from hardware
 measurements. The training example runs on your local machine; these calls

--- a/docs/api-changes/FQ-QUAFU-SERVICE-COMPILATION.md
+++ b/docs/api-changes/FQ-QUAFU-SERVICE-COMPILATION.md
@@ -1,0 +1,38 @@
+# Quafu service compilation through fq.run
+
+## Decision and authorization
+
+The repository owner explicitly approved this journey in the implementation
+conversation: omit the local compiler for direct Quafu submission; preserve
+explicit QSteed compilation. Approval covers this narrowly scoped behavior
+extension. Status: implemented candidate, pending review and release.
+
+## User journey and compatibility
+
+`fq.run(circuit, target="quafu:Baihua", shots=1024)` submits logical OpenQASM
+with `options.compiler="quarkcircuit"`. No local QSteed or Quark SDK is loaded,
+and no local calibration lookup is required. Optional `target_qubits` is
+validated structurally; the service validates physical availability/topology.
+FlagQuantum still lowers and serializes its IR and inserts measurement bases;
+it does not perform device-specific routing in this path.
+
+The public signature, exports, serialized schemas and existing successful calls
+remain unchanged. This previously rejected argument combination is now accepted.
+`compiler="qsteed"` retains local plugin compilation and `options.compiler=None`
+submission. No deprecated argument or removal window is needed. The root API is
+appropriate because both paths return the existing ExecutionResult, support the
+same output requests, and represent the same execute-on-target journey.
+
+## Evidence and validation
+
+Service-compiled results record `compiler=None`, `compilation_location="service"`
+and `service_compiler="quarkcircuit"`. Submission digests identify submitted
+artifacts, not the circuit ultimately executed by the service. Returned
+`transpiled` data remains provider evidence; local tests cannot certify hardware
+execution or physical mapping chosen by the service.
+
+Tests block local compiler/SDK imports and calibration requests, exercise the
+actual HTTP adapter with a fake transport, check counts and grouped expectations,
+and reject invalid mappings/shots before submission. Existing precompiled
+provider and root execution contracts are retained. API snapshots are not
+regenerated. The Quafu guide and unreleased notes document the new journey.

--- a/docs/api-changes/FQ-QUAFU-SERVICE-COMPILATION.md
+++ b/docs/api-changes/FQ-QUAFU-SERVICE-COMPILATION.md
@@ -25,6 +25,11 @@ same output requests, and represent the same execute-on-target journey.
 
 ## Evidence and validation
 
+The direct path converts Quafu's classical-MSB-left count strings to
+FlagQuantum's measurement-wires-left-to-right ordering before expectation
+aggregation. The existing explicit-precompilation path is unchanged. An
+asymmetric fixture covers this boundary; Bell-only counts cannot detect it.
+
 Service-compiled results record `compiler=None`, `compilation_location="service"`
 and `service_compiler="quarkcircuit"`. Submission digests identify submitted
 artifacts, not the circuit ultimately executed by the service. Returned

--- a/docs/guides/QUAFU_BACKEND.md
+++ b/docs/guides/QUAFU_BACKEND.md
@@ -20,7 +20,9 @@ print(result.counts)
 
 Configure `QUAFU_API_TOKEN` as described below. This path sends logical OpenQASM
 with `options.compiler="quarkcircuit"` and does not require local QSteed or
-QuarkCircuit installation. The service handles compilation and physical routing.
+QuarkCircuit installation. The service handles compilation and physical routing. Direct-path counts are
+returned in logical-wire order (wire 0 on the left), including before expectation
+aggregation; raw provider metadata retains the original response.
 `outputs=fq.expectation(...)` remains supported through grouped basis measurements.
 Optional `target_qubits` selects an ordered physical mapping; its size and
 uniqueness are checked locally, while chip availability/topology are checked by

--- a/docs/guides/QUAFU_BACKEND.md
+++ b/docs/guides/QUAFU_BACKEND.md
@@ -3,7 +3,38 @@
 FlagQuantum talks directly to the HTTP contract implemented by
 `quafusqc.Task`; installing `quafusqc` is not required.
 
-## Install the compiler plugin
+## Direct submission (service compilation)
+
+The development version supports Quafu submission without a local compiler:
+
+```python
+import flagquantum as fq
+
+result = fq.run(
+    fq.Circuit(2).h(0).cx(0, 1),
+    target="quafu:Baihua",
+    shots=1024,
+)
+print(result.counts)
+```
+
+Configure `QUAFU_API_TOKEN` as described below. This path sends logical OpenQASM
+with `options.compiler="quarkcircuit"` and does not require local QSteed or
+QuarkCircuit installation. The service handles compilation and physical routing.
+`outputs=fq.expectation(...)` remains supported through grouped basis measurements.
+Optional `target_qubits` selects an ordered physical mapping; its size and
+uniqueness are checked locally, while chip availability/topology are checked by
+the service. Shots must be a positive multiple of 1024.
+
+The published 0.2.0 release predates this direct-submission feature. Use a source
+checkout containing this change until the next release is published.
+
+For local compilation before submission, explicitly pass `compiler="qsteed"`
+and install the plugin below. The service compiler option is distinct from the
+root API's local compiler selection. A submitted circuit digest is not evidence
+of the final circuit executed on hardware; inspect returned `transpiled` data.
+
+## Optional local compiler plugin
 
 The Quafu examples use the independently maintained
 [FlagQuantum Compiler QSteed](https://github.com/FlagQuantum/FlagQuantum-Compiler-QSteed)

--- a/docs/reference/RELEASE_NOTES.md
+++ b/docs/reference/RELEASE_NOTES.md
@@ -17,6 +17,12 @@ Benchmark claims require audited artifacts and are not inferred from this file.
 
 ## Unreleased
 
+- Added direct Quafu execution through `fq.run(..., target="quafu:Baihua", shots=1024)`
+  without a local compiler dependency. The service uses QuarkCircuit compilation;
+  explicit `compiler="qsteed"` preserves local precompilation. Counts and grouped
+  Pauli expectations share the existing result contract. This path has mocked
+  transport coverage; live service compilation is not yet validated.
+
 - Renamed the VQE and ADAPT-VQE `optimizer_cls` keyword to
   `optimizer_factory` and published the `flagquantum.algorithms.OptimizerFactory`
   protocol. The old keyword is intentionally unsupported; Adam remains the

--- a/examples/remote/quafu_bell.py
+++ b/examples/remote/quafu_bell.py
@@ -1,7 +1,6 @@
-"""Compile and run a Bell circuit on Quafu SQC.
+"""Submit a Bell circuit for service compilation and execution on Quafu SQC.
 
-Set ``QUAFU_API_TOKEN`` and install ``flagquantum-compiler-qsteed`` before
-running this example. The selected chip name must exist in the current Quafu
+Set ``QUAFU_API_TOKEN`` before running this example. The selected chip name must exist in the current Quafu
 account.
 """
 
@@ -19,7 +18,6 @@ def main() -> None:
     circuit = fq.Circuit(2).h(0).cx(0, 1)
     result = fq.run(
         circuit,
-        compiler="qsteed",
         target="quafu:Baihua",
         shots=1024,
         name="flagquantum bell",

--- a/flagquantum/_api.py
+++ b/flagquantum/_api.py
@@ -157,7 +157,7 @@ def run(
             name=name,
         )
 
-    if compiler is None or target is None:
+    if target is None:
         raise TypeError("remote execution requires both compiler and target")
     if options is not None or noise_model is not None:
         raise TypeError(
@@ -175,6 +175,18 @@ def run(
     from .remote.qpu.execution import execute_quafu, validate_quafu_output
 
     output = validate_quafu_output(program_or_plan, outputs)
+    if compiler is None:
+        if shots % 1024:
+            raise ValueError("Quafu shots must be a positive multiple of 1024")
+        return execute_quafu(
+            import_module(".core.ir", __package__).ensure_circuit_ir(program_or_plan),
+            output=output,
+            compiler=None,
+            target=target,
+            shots=shots,
+            name=name,
+            target_qubits=target_qubits,
+        )
     compiled = compile(
         program_or_plan,
         compiler=compiler,

--- a/flagquantum/_api.py
+++ b/flagquantum/_api.py
@@ -157,7 +157,9 @@ def run(
             name=name,
         )
 
-    if target is None:
+    if target is None or (
+        compiler is None and not (separator == ":" and provider_name.lower() == "quafu")
+    ):
         raise TypeError("remote execution requires both compiler and target")
     if options is not None or noise_model is not None:
         raise TypeError(

--- a/flagquantum/remote/qpu/execution.py
+++ b/flagquantum/remote/qpu/execution.py
@@ -1,17 +1,21 @@
-"""Compose one compiled Quafu execution into a FlagQuantum result."""
+"""Compose local-compiled or service-compiled Quafu execution into a result."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ...algorithms import Hamiltonian, HamiltonianTerm
 from ...core.ir import ensure_circuit_ir
-from ...deployment import create_pauli_measurement_plan, deploy_circuit
+from ...deployment import (
+    CloudBackendProfile,
+    create_pauli_measurement_plan,
+    deploy_circuit,
+)
 from ...observables import OutputRequest
 from ...observables import counts as request_counts
 from ...runtime.result import ExecutionResult, MeasurementResult
-from .quafu import QuafuProvider
+from .quafu import QuafuProvider, _service_options
 
 if TYPE_CHECKING:
     from ...circuit import Circuit
@@ -23,13 +27,35 @@ def execute_quafu(
     compiled: CircuitIR,
     *,
     output: OutputRequest,
-    compiler: str,
+    compiler: str | None,
     target: str,
     shots: int,
     name: str | None,
+    target_qubits: Sequence[int] | None = None,
 ) -> ExecutionResult:
     """Submit one compiled circuit and normalize its Quafu result."""
 
+    package_options: dict[str, Any] = {}
+    if compiler is None:
+        backend = target.partition(":")[2].strip()
+        if not backend:
+            raise ValueError("Quafu target must name a backend")
+        if compiled.metadata.get("execution_target"):
+            raise ValueError("service compilation requires an unbound logical circuit")
+        options = _service_options(
+            compiled.n_wires, () if target_qubits is None else target_qubits
+        )
+        package_options = {
+            "backend": CloudBackendProfile(
+                provider="quafu", name=backend, n_wires=compiled.n_wires
+            ),
+            "optimize": False,
+            "metadata": {
+                "provider_options": options,
+                "compilation_location": "service",
+                "service_compiler": "quarkcircuit",
+            },
+        }
     provider = QuafuProvider()
     if output.kind == "expectation":
         return _execute_expectation(
@@ -40,6 +66,7 @@ def execute_quafu(
             target=target,
             shots=shots,
             name=name,
+            package_options=package_options,
         )
     return _execute_counts(
         compiled,
@@ -49,6 +76,7 @@ def execute_quafu(
         target=target,
         shots=shots,
         name=name,
+        package_options=package_options,
     )
 
 
@@ -100,10 +128,11 @@ def _execute_expectation(
     *,
     provider: QuafuProvider,
     output: OutputRequest,
-    compiler: str,
+    compiler: str | None,
     target: str,
     shots: int,
     name: str | None,
+    package_options: dict[str, Any],
 ) -> ExecutionResult:
     assert output.observable is not None
     hamiltonian = Hamiltonian(
@@ -119,6 +148,7 @@ def _execute_expectation(
         hamiltonian,
         name=deployment_name,
         shots=shots,
+        **package_options,
     )
     native_results = tuple(
         provider.run(package) for package in measurement_plan.packages
@@ -126,7 +156,11 @@ def _execute_expectation(
     grouped_counts = tuple(result.counts for result in native_results)
     value = measurement_plan.expectation(grouped_counts)
     standard_error = measurement_plan.standard_error(grouped_counts)
-    execution_target = dict(compiled.metadata.get("execution_target", {}))
+    execution_target = (
+        compiled.metadata.get("execution_target", {})
+        if compiler is not None
+        else package_options["metadata"]["provider_options"]
+    )
     task_ids = tuple(result.handle.task_id for result in native_results)
     group_evidence = tuple(
         {
@@ -178,6 +212,11 @@ def _execute_expectation(
             "compiler": compiler,
             "target": target,
             "target_qubits": tuple(execution_target.get("target_qubits", ())),
+            **(
+                {"compilation_location": "service", "service_compiler": "quarkcircuit"}
+                if compiler is None
+                else {}
+            ),
             "name": deployment_name,
             "measurement_plan": measurement_plan.summary(),
             "measurement_groups": group_evidence,
@@ -197,19 +236,26 @@ def _execute_counts(
     *,
     provider: QuafuProvider,
     output: OutputRequest,
-    compiler: str,
+    compiler: str | None,
     target: str,
     shots: int,
     name: str | None,
+    package_options: dict[str, Any],
 ) -> ExecutionResult:
     if name is None:
-        native = deploy_circuit(compiled, provider, shots=shots)
+        native = deploy_circuit(compiled, provider, shots=shots, **package_options)
     else:
-        native = deploy_circuit(compiled, provider, shots=shots, name=name.strip())
+        native = deploy_circuit(
+            compiled, provider, shots=shots, name=name.strip(), **package_options
+        )
     counts: dict[str | int, int] = {
         str(key): int(value) for key, value in native.counts.items()
     }
-    execution_target = dict(compiled.metadata.get("execution_target", {}))
+    execution_target = (
+        compiled.metadata.get("execution_target", {})
+        if compiler is not None
+        else package_options["metadata"]["provider_options"]
+    )
     result = ExecutionResult(
         measurements=(
             MeasurementResult(
@@ -235,6 +281,11 @@ def _execute_counts(
             "compiler": compiler,
             "target": target,
             "target_qubits": tuple(execution_target.get("target_qubits", ())),
+            **(
+                {"compilation_location": "service", "service_compiler": "quarkcircuit"}
+                if compiler is None
+                else {}
+            ),
             "name": name.strip() if name is not None else "flagquantum_job",
             "deployment": dict(native.metadata),
         },

--- a/flagquantum/remote/qpu/execution.py
+++ b/flagquantum/remote/qpu/execution.py
@@ -56,7 +56,10 @@ def execute_quafu(
                 "service_compiler": "quarkcircuit",
             },
         }
-    provider = QuafuProvider()
+    # Quafu reports c[N-1]...c[0]; the direct path exposes logical wires 0...N-1.
+    provider = (
+        QuafuProvider(reverse_result_bits=True) if compiler is None else QuafuProvider()
+    )
     if output.kind == "expectation":
         return _execute_expectation(
             compiled,
@@ -213,7 +216,11 @@ def _execute_expectation(
             "target": target,
             "target_qubits": tuple(execution_target.get("target_qubits", ())),
             **(
-                {"compilation_location": "service", "service_compiler": "quarkcircuit"}
+                {
+                    "compilation_location": "service",
+                    "service_compiler": "quarkcircuit",
+                    "counts_bit_order": "measurement_wires_left_to_right",
+                }
                 if compiler is None
                 else {}
             ),
@@ -282,7 +289,11 @@ def _execute_counts(
             "target": target,
             "target_qubits": tuple(execution_target.get("target_qubits", ())),
             **(
-                {"compilation_location": "service", "service_compiler": "quarkcircuit"}
+                {
+                    "compilation_location": "service",
+                    "service_compiler": "quarkcircuit",
+                    "counts_bit_order": "measurement_wires_left_to_right",
+                }
                 if compiler is None
                 else {}
             ),

--- a/flagquantum/remote/qpu/quafu.py
+++ b/flagquantum/remote/qpu/quafu.py
@@ -30,13 +30,43 @@ _QREG_DECLARATION = re.compile(r"\bqreg\s+q\s*\[\s*(\d+)\s*\]\s*;")
 _QUBIT_REFERENCE = re.compile(r"\bq\s*\[\s*(\d+)\s*\]")
 
 
+def _service_options(n_wires: int, raw_qubits: Sequence[int]) -> dict[str, Any]:
+    """Validate the optional physical mapping before any remote side effect."""
+    if not isinstance(raw_qubits, Sequence) or isinstance(raw_qubits, (str, bytes)):
+        raise ValueError("target_qubits must be a sequence of physical qubits")
+    qubits = list(raw_qubits)
+    if qubits and (
+        len(qubits) != n_wires
+        or any(type(qubit) is not int or qubit < 0 for qubit in qubits)
+        or len(set(qubits)) != len(qubits)
+    ):
+        raise ValueError(
+            "target_qubits must map every logical wire to a unique nonnegative integer"
+        )
+    return {"compiler": "quarkcircuit", "target_qubits": qubits}
+
+
 def _submission_options(
     qasm: str,
     *,
     n_wires: int,
     options: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Validate the Quafu contract for an already compiled logical circuit."""
+    """Validate the selected service-compilation or precompiled submission contract."""
+
+    if options.get("compiler") == "quarkcircuit":
+        resolved = _service_options(n_wires, options.get("target_qubits", ()))
+        declaration = _QREG_DECLARATION.search(qasm)
+        if declaration is None or int(declaration.group(1)) != n_wires:
+            raise ValueError("Quafu QASM must declare logical qreg q[N]")
+        if any(
+            int(index) >= n_wires
+            for index in _QUBIT_REFERENCE.findall(
+                _QREG_DECLARATION.sub("", qasm, count=1)
+            )
+        ):
+            raise ValueError("Quafu QASM references an out-of-range logical wire")
+        return {**options, **resolved}
 
     if "compiler" not in options or options["compiler"] is not None:
         raise ValueError("precompiled Quafu submissions require compiler=None")

--- a/tests/api_contract/test_quafu_service_compile.py
+++ b/tests/api_contract/test_quafu_service_compile.py
@@ -1,0 +1,100 @@
+"""Direct Quafu submission does not load a local compiler or calibration SDK."""
+
+import builtins
+from unittest.mock import Mock
+
+import pytest
+
+import flagquantum as fq
+from flagquantum.remote.qpu.quafu import QuafuProvider
+
+
+class Transport:
+    def __init__(self):
+        self.posts = []
+        self.gets = []
+
+    def post_json(self, url, payload, headers, timeout):
+        self.posts.append((url, payload))
+        return {"task_id": f"job-{len(self.posts)}"}
+
+    def get_json(self, url, headers, timeout):
+        self.gets.append(url)
+        if "/task/status/" in url:
+            return {"status": "Finished"}
+        if "/task/result/" in url:
+            return {
+                "status": "Finished",
+                "count": {"10": 1024},
+                "transpiled": "service circuit",
+            }
+        raise AssertionError(f"Unexpected discovery/calibration request: {url}")
+
+
+@pytest.fixture
+def transport(monkeypatch):
+    transport = Transport()
+    provider = QuafuProvider(base_url="https://quafu.test", transport=transport)
+    monkeypatch.setattr(
+        "flagquantum.remote.qpu.execution.QuafuProvider", lambda: provider
+    )
+    monkeypatch.setattr(
+        "flagquantum._api.compile",
+        Mock(side_effect=AssertionError("local plugin called")),
+    )
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name.split(".")[0] in {"qsteed", "flagquantum_compiler_qsteed", "quark"}:
+            raise AssertionError(f"Local compiler dependency loaded: {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    return transport
+
+
+def test_direct_counts_with_service_compilation(transport):
+    result = fq.run(fq.Circuit(2).x(0), target="quafu:Baihua", shots=1024)
+    url, payload = transport.posts[0]
+    assert "chip=Baihua" in url
+    assert payload["options"] == {"compiler": "quarkcircuit", "target_qubits": []}
+    assert "qreg q[2];" in payload["circuit"]
+    assert result.counts == [{"10": 1024}]
+    assert result.provenance["compiler"] is None
+    assert result.provenance["compilation_location"] == "service"
+    assert result.provenance["service_compiler"] == "quarkcircuit"
+    assert result.provenance["deployment"]["transpiled"] == "service circuit"
+
+
+def test_direct_expectations_keep_rotations_grouping_and_requested_mapping(transport):
+    result = fq.run(
+        fq.Circuit(2),
+        target="quafu:Baihua",
+        shots=1024,
+        target_qubits=(17, 18),
+        outputs=fq.expectation(fq.X(0) + fq.Z(0)),
+    )
+    assert len(transport.posts) == 2
+    assert all(
+        p["options"] == {"compiler": "quarkcircuit", "target_qubits": [17, 18]}
+        for _, p in transport.posts
+    )
+    assert any("h q[0]" in p["circuit"] for _, p in transport.posts)
+    assert result.expectation().item() == -2
+    assert result.provenance["target_qubits"] == (17, 18)
+
+
+@pytest.mark.parametrize("mapping", [(1,), (1, 1), (-1, 2), (True, 2), (1.5, 2), "12"])
+def test_invalid_mapping_never_submits(transport, mapping):
+    with pytest.raises(ValueError, match="target_qubits"):
+        fq.run(fq.Circuit(2), target="quafu:Baihua", shots=1024, target_qubits=mapping)
+    assert not transport.posts
+
+
+@pytest.mark.parametrize(
+    "options", [{"shots": 12}, {"shots": 1024, "target": "quafu:"}]
+)
+def test_invalid_service_request_never_submits(transport, options):
+    with pytest.raises(ValueError):
+        fq.run(fq.Circuit(2), **{"target": "quafu:Baihua", **options})
+    assert not transport.posts

--- a/tests/api_contract/test_quafu_service_compile.py
+++ b/tests/api_contract/test_quafu_service_compile.py
@@ -25,7 +25,7 @@ class Transport:
         if "/task/result/" in url:
             return {
                 "status": "Finished",
-                "count": {"10": 1024},
+                "count": {"01": 1024},
                 "transpiled": "service circuit",
             }
         raise AssertionError(f"Unexpected discovery/calibration request: {url}")
@@ -34,9 +34,11 @@ class Transport:
 @pytest.fixture
 def transport(monkeypatch):
     transport = Transport()
-    provider = QuafuProvider(base_url="https://quafu.test", transport=transport)
     monkeypatch.setattr(
-        "flagquantum.remote.qpu.execution.QuafuProvider", lambda: provider
+        "flagquantum.remote.qpu.execution.QuafuProvider",
+        lambda **options: QuafuProvider(
+            base_url="https://quafu.test", transport=transport, **options
+        ),
     )
     monkeypatch.setattr(
         "flagquantum._api.compile",
@@ -60,6 +62,7 @@ def test_direct_counts_with_service_compilation(transport):
     assert payload["options"] == {"compiler": "quarkcircuit", "target_qubits": []}
     assert "qreg q[2];" in payload["circuit"]
     assert result.counts == [{"10": 1024}]
+    assert result.provenance["counts_bit_order"] == "measurement_wires_left_to_right"
     assert result.provenance["compiler"] is None
     assert result.provenance["compilation_location"] == "service"
     assert result.provenance["service_compiler"] == "quarkcircuit"

--- a/tests/team/remote/test_quafu_user_path.py
+++ b/tests/team/remote/test_quafu_user_path.py
@@ -27,8 +27,7 @@ def test_quafu_bell_example_uses_complete_public_path(monkeypatch, capsys) -> No
 
     assert captured["program"].n_qubits == 2
     assert captured["options"] == {
-        "compiler": "qsteed",
-        "target": "quafu:ScQ-P10",
+        "target": "quafu:Baihua",
         "shots": 1024,
         "name": "flagquantum bell",
     }


### PR DESCRIPTION
## Change

Allow `fq.run(circuit, target="quafu:Baihua", shots=1024)` without installing a local compiler. FlagQuantum serializes the logical circuit and requests `options.compiler="quarkcircuit"` from Quafu. Explicit `compiler="qsteed"` retains the existing local-compilation path and precompiled submission contract.

Reuse measurement grouping, deployment identity, polling and result parsing for counts and Pauli expectations. Validate optional physical mappings before submission and record service compilation separately from the returned executed circuit. Normalize direct-path Quafu classical-MSB-left counts into logical-wire order before returning counts or aggregating expectations. An asymmetric test covers the bit-order boundary.

No public signatures or API snapshots change. The owner-approved behavior extension is recorded in `docs/api-changes/FQ-QUAFU-SERVICE-COMPILATION.md`. Update the README, Quafu guide, release notes and Bell example; the guide distinguishes this source change from the published 0.2.0 release.

## Validation

- Broad local smoke/unit/integration regression: 2,456 passed, 35 skipped, with local loopback communication enabled.
- After the final direct-path bit-order refinement, all 40 focused API/provider/example tests passed, including 10 new transport tests that reject local QSteed/Quark imports and calibration requests.
- API baseline, Ruff, formatting and diff checks passed. Protected snapshots were not regenerated.
- No live quantum jobs were submitted. Hardware results and service-side routing are not certified by mocked transport tests. CI on the latest PR head must pass before merge.
