### PR TITLE
feat: add resumable Quafu and native Jiuding jobs

### DIFF
--- a/contracts/public-api-v1-candidate.json
+++ b/contracts/public-api-v1-candidate.json
@@ -15,10 +15,10 @@
       "ExecutionOptions",
       "ExecutionPlan",
       "ExecutionResult",
+      "I",
       "IRSerializationError",
       "IRValidationError",
       "IR_VERSION",
-      "I",
       "Instruction",
       "MeasurementResult",
       "Module",
@@ -38,8 +38,10 @@
       "experimental",
       "plan",
       "probabilities",
+      "restore_job",
       "run",
       "samples",
+      "submit",
       "train"
     ],
     "planned_additions": []

--- a/contracts/public-api-v1-candidate.json
+++ b/contracts/public-api-v1-candidate.json
@@ -215,7 +215,7 @@
     "compile_for_backend": "flagquantum.compile"
   },
   "rules": {
-    "root_export_budget": 32,
+    "root_export_budget": 33,
     "root_backend_specific_exports": 0,
     "root_evidence_exports": 0,
     "breaking_changes_require_approved_proposal": true,

--- a/contracts/remote-jobs-v1-candidate.json
+++ b/contracts/remote-jobs-v1-candidate.json
@@ -11,7 +11,7 @@
     "restore_job"
   ],
   "public_signatures": {
-    "submit": "(program: 'Circuit | CircuitIR', *, target: 'str', outputs: 'OutputRequest | Sequence[OutputRequest] | None' = None, shots: 'int | None' = None, compiler: 'str | None' = None, target_qubits: 'Sequence[int] | None' = None, name: 'str | None' = None, image: 'str | None' = None, workspace: 'str | None' = None) -> 'RemoteJob'",
+    "submit": "(program: 'Circuit | CircuitIR', *, target: 'str', outputs: 'OutputRequest | Sequence[OutputRequest] | None' = None, shots: 'int | None' = None, compiler: 'str | None' = None, target_qubits: 'Sequence[int] | None' = None, name: 'str | None' = None, image: 'str | None' = None, workspace: 'str | None' = None, project: 'str | None' = None, queue: 'str | None' = None) -> 'RemoteJob'",
     "restore_job": "(path: 'str | Path') -> 'RemoteJob'",
     "RemoteJob.status": "(self) -> 'JobStatus'",
     "RemoteJob.result": "(self) -> 'ExecutionResult'",

--- a/contracts/remote-jobs-v1-candidate.json
+++ b/contracts/remote-jobs-v1-candidate.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0",
+  "implementation_authorized": true,
+  "approval": {
+    "owner": "Repository API owner via conversation",
+    "date": "2026-09-11",
+    "proposal": "docs/api-changes/FQ-REMOTE-JOBS.md"
+  },
+  "root_additions": [
+    "submit",
+    "restore_job"
+  ],
+  "public_signatures": {
+    "submit": "(program: 'Circuit | CircuitIR', *, target: 'str', outputs: 'OutputRequest | Sequence[OutputRequest] | None' = None, shots: 'int | None' = None, compiler: 'str | None' = None, target_qubits: 'Sequence[int] | None' = None, name: 'str | None' = None, image: 'str | None' = None, workspace: 'str | None' = None) -> 'RemoteJob'",
+    "restore_job": "(path: 'str | Path') -> 'RemoteJob'",
+    "RemoteJob.status": "(self) -> 'JobStatus'",
+    "RemoteJob.result": "(self) -> 'ExecutionResult'",
+    "RemoteJob.wait": "(self, timeout: 'float' = 300.0, poll_interval: 'float' = 3.0) -> 'ExecutionResult'",
+    "RemoteJob.cancel": "(self) -> 'None'",
+    "RemoteJob.save": "(self, path: 'str | Path') -> 'None'"
+  },
+  "statuses": [
+    "queued",
+    "running",
+    "succeeded",
+    "failed",
+    "cancelled",
+    "unknown"
+  ],
+  "receipt_schema": "flagquantum.remote-job.v1"
+}

--- a/docs/api-changes/FQ-REMOTE-JOBS.md
+++ b/docs/api-changes/FQ-REMOTE-JOBS.md
@@ -20,8 +20,12 @@ thread, event loop, service, registry, or automatic retry is introduced.
 Quafu initially supports full-register counts, with service-side or explicit
 local compilation. Grouped expectations must use `run`; they are rejected before
 submission because multiple provider IDs need a separately designed group API.
-Jiuding uses existing managed batch jobs and requires an explicit image. This is
-different from `run`'s resident-workspace execution and is documented accordingly.
+The owner subsequently required native Jiuding job mode without SSH, using a
+project and queue. The authorized candidate adds `project` and `queue` arguments
+and rejects `workspace` for new submissions. Jiuding submits an inline circuit
+through HTTP, runs the image-installed executor, and retrieves bounded results
+through authenticated job logs. It requires an explicit image. Synchronous `run`
+retains its resident-workspace behavior. No released API is removed.
 
 A job exposes `id`, `target`, `raw_status`, `status()`, `result()`,
 `wait(timeout=300.0, poll_interval=3.0)`, `cancel()`, and `save(path)`.
@@ -36,8 +40,9 @@ credentials from the current environment. A new receipt stores only identity and
 result decoding context. It contains no credentials or executable payload. Files
 are created exclusively with owner-only access; callers retain them privately.
 This preserves output names, physical mapping, and count ordering across restarts.
-Saved Jiuding IDs are resolved through the configured workspace's existing
-managed-receipt mechanism.
+Jiuding receipts retain project, queue, experiment and job identities plus log
+decoding context. Older development receipts remain readable through their
+existing managed-workspace transport; new receipts require no workspace.
 
 ## Validation and release
 
@@ -49,4 +54,6 @@ clients establish lifecycle semantics, not hardware or cluster availability.
 
 A [Quafu hardware check](../development/evidence/remote_jobs_quafu_20260911.json)
 completed submission and separate-process restoration for one counts task.
-Jiuding lifecycle tests use a fake client; no new live Jiuding job was submitted.
+A [native Jiuding A100 job](../development/evidence/remote_jobs_jiuding_20260911.json) also completed with exact two-qubit X counts (1024
+shots), using HTTP submission and separate-process log retrieval without SSH.
+This is a small correctness check, not a performance or scalability claim.

--- a/docs/api-changes/FQ-REMOTE-JOBS.md
+++ b/docs/api-changes/FQ-REMOTE-JOBS.md
@@ -10,6 +10,10 @@ on 2026-09-11 (affirmative reply to the concrete proposal). This additive change
 These names describe operations independently of any provider implementation.
 Existing `run` behavior, signatures, and historical API baseline stay unchanged.
 Status: authorized implementation candidate, not a released feature.
+The two approved root additions bring the retained core from 31 to 33 exports;
+the candidate root budget is therefore 33 (previously 32). Historical exports
+and signatures remain frozen; authorization is read from this proposal's
+contract by both the snapshot validator and the candidate unit tests.
 
 ## Scope and compatibility
 

--- a/docs/api-changes/FQ-REMOTE-JOBS.md
+++ b/docs/api-changes/FQ-REMOTE-JOBS.md
@@ -1,0 +1,52 @@
+# Remote job lifecycle
+
+## Authorization and naming
+
+The API owner approved the proposed `fq.submit` job journey in this conversation
+on 2026-09-11 (affirmative reply to the concrete proposal). This additive change introduces `submit` and
+`restore_job` at the root, and `RemoteJob` in `flagquantum.remote.jobs`.
+`submit` starts work, `status` queries once, `result` retrieves without polling,
+`wait` explicitly polls with a deadline, and `cancel` requests cancellation.
+These names describe operations independently of any provider implementation.
+Existing `run` behavior, signatures, and historical API baseline stay unchanged.
+Status: authorized implementation candidate, not a released feature.
+
+## Scope and compatibility
+
+Remote submission is a separate user journey from synchronous execution, so two
+root operations are justified. A thin job object composes existing Quafu and
+Jiuding clients; it owns no simulation or compilation passes. No new dependency,
+thread, event loop, service, registry, or automatic retry is introduced.
+Quafu initially supports full-register counts, with service-side or explicit
+local compilation. Grouped expectations must use `run`; they are rejected before
+submission because multiple provider IDs need a separately designed group API.
+Jiuding uses existing managed batch jobs and requires an explicit image. This is
+different from `run`'s resident-workspace execution and is documented accordingly.
+
+A job exposes `id`, `target`, `raw_status`, `status()`, `result()`,
+`wait(timeout=300.0, poll_interval=3.0)`, `cancel()`, and `save(path)`.
+States are `queued`, `running`, `succeeded`, `failed`, `cancelled`, or `unknown`.
+Unknown states and missing job records never imply success. Result retrieval
+raises an execution error when unfinished or failed. Wait raises TimeoutError
+without cancellation or resubmission. Transport errors propagate; no remote side
+effect is automatically retried. Cancel is a request, not proof of cancellation.
+
+`restore_job(path)` reads a versioned JSON receipt, never submits, and reloads
+credentials from the current environment. A new receipt stores only identity and
+result decoding context. It contains no credentials or executable payload. Files
+are created exclusively with owner-only access; callers retain them privately.
+This preserves output names, physical mapping, and count ordering across restarts.
+Saved Jiuding IDs are resolved through the configured workspace's existing
+managed-receipt mechanism.
+
+## Validation and release
+
+Conformance tests cover both providers, unfinished/failed/unknown states,
+nonblocking result access, deadlines, cancellation, save/restore and no duplicate
+submission. New contracts record only the authorized additions; the historical
+baseline is not regenerated. No deprecation or removal applies. Tests using fake
+clients establish lifecycle semantics, not hardware or cluster availability.
+
+A [Quafu hardware check](../development/evidence/remote_jobs_quafu_20260911.json)
+completed submission and separate-process restoration for one counts task.
+Jiuding lifecycle tests use a fake client; no new live Jiuding job was submitted.

--- a/docs/development/evidence/remote_jobs_jiuding_20260911.json
+++ b/docs/development/evidence/remote_jobs_jiuding_20260911.json
@@ -1,0 +1,31 @@
+{
+  "date": "2026-09-11",
+  "provider": "jiuding",
+  "mode": "native_http_job",
+  "job_id": "8996b8db-9bd6-44f6-bf79-e88d5cd802fd",
+  "circuit": "2 qubits, X(0)",
+  "shots": 1024,
+  "counts": [
+    {
+      "10": 1024
+    }
+  ],
+  "runtime": {
+    "execution_path": "jiuding_batch_program",
+    "device": "cuda:0",
+    "elapsed_seconds": 0.495859419927001,
+    "result_transfer": "device_to_host",
+    "counts_aggregation": "host"
+  },
+  "provenance": {
+    "requested_target": "jiuding:gpu",
+    "selected_target": "jiuding:gpu/NVIDIA_A100-SXM4-40GB",
+    "accelerator": "NVIDIA A100-SXM4-40GB",
+    "cpu_fallback_used": false,
+    "statevector_transferred": false
+  },
+  "separate_process_restore": true,
+  "ssh_and_workspace_calls_forbidden": true,
+  "restoration_resubmission_forbidden": true,
+  "scope": "Single-GPU small-circuit correctness; not a performance or scalability validation."
+}

--- a/docs/development/evidence/remote_jobs_quafu_20260911.json
+++ b/docs/development/evidence/remote_jobs_quafu_20260911.json
@@ -1,0 +1,18 @@
+{
+  "scope": "One two-qubit X(0) circuit, Quafu Baihua hardware, service compilation; no Jiuding live test or performance certification",
+  "date": "2026-09-11",
+  "branch": "feat/remote-job-lifecycle",
+  "task_id": "2609112037201263021",
+  "submitted_shots": 1024,
+  "counts": {
+    "10": 938,
+    "00": 71,
+    "11": 15
+  },
+  "submit_elapsed_seconds": 0.08,
+  "compiler": "quarkcircuit",
+  "restored_in_separate_python_process": true,
+  "initial_status": "unknown (provider task not found immediately after acknowledgement)",
+  "subsequent_raw_status": "Transpiled",
+  "outcome": "completed"
+}

--- a/docs/generated/STABLE_API.md
+++ b/docs/generated/STABLE_API.md
@@ -32,6 +32,8 @@ Do not edit. Source: `docs/public_api_v1.json`.
 | `fq.experimental` | Stable | executable contract |
 | `fq.plan` | Stable | executable contract |
 | `fq.probabilities` | Stable | executable contract |
+| `fq.restore_job` | Stable | executable contract |
 | `fq.run` | Stable | executable contract |
 | `fq.samples` | Stable | executable contract |
+| `fq.submit` | Stable | executable contract |
 | `fq.train` | Stable | executable contract |

--- a/docs/guides/JIUDING.md
+++ b/docs/guides/JIUDING.md
@@ -11,6 +11,11 @@ and refresh according to the server expiry. Requests use HTTPS, reject redirects
 have a 20-second socket timeout, and are not retried blindly. No CLI installation
 or manual project and queue IDs are required.
 
+For native jobs without a workspace or SSH, use the development-version
+[`fq.submit()` journey](REMOTE_JOBS.md#jiuding-native-jobs). It requires project
+membership, queue capacity and a compatible image. The workspace examples below
+remain useful for repeated interactive execution and shared-storage jobs.
+
 ## First account check
 
 A new account must first be added to a Jiuding project and an active compute
@@ -46,17 +51,19 @@ available runtime image remain platform administration operations.
 
 ## Choose an execution path
 
-Jiuding has two primary execution paths. They return the same FlagQuantum
+Jiuding offers native jobs and workspace-backed execution. They return the same FlagQuantum
 result type but have different latency and lifecycle semantics.
 
 | Need | Entry point | Required resource | Lifecycle |
 | --- | --- | --- | --- |
 | Interactive or repeated execution | [`fq.run(..., target="jiuding:...")`](#repeated-low-latency-workspace-execution) | A running development workspace | Reuses one resident process and SSH channel; no Job ID |
-| Isolated, schedulable, recoverable work | [`JiudingClient.submit_program(...)`](#recoverable-batch-execution) | A running workspace, runtime image and queue capacity | Creates a batch Job; recoverable by Job ID |
+| Native detached circuits (development version) | [`fq.submit(...)`](REMOTE_JOBS.md#jiuding-native-jobs) | Project, queue and runtime image | HTTP submission and bounded log results; no SSH or workspace |
+| Shared-storage, recoverable work | [`JiudingClient.submit_program(...)`](#recoverable-batch-execution) | A running workspace, runtime image and queue capacity | Creates a batch Job; recoverable by Job ID |
 
 Use `fq.run` when startup latency would dominate the calculation. Use
 `submit_program` when the work should survive the caller process, wait in the
-queue, or be recovered later. Neither path creates a development workspace
+queue, or be recovered later. Use `fq.submit` for native jobs without shared
+storage or workspace discovery. None of these paths creates a development workspace
 implicitly. `JiudingClient.submit()` is the advanced escape hatch for an
 existing Python script and shared-storage layout; ordinary circuit users do
 not need it.
@@ -366,8 +373,9 @@ cancels. `client.cancel(receipt)` requests that active jobs stop and does not
 archive/delete experiments. Check status afterward to verify termination.
 If launch is still uncertain and no jobs are visible, an empty status/cancel
 result does not establish that no job exists. Queue quota availability and
-scheduler delay remain platform concerns. Log streaming, automatic resume from
-partial creation, multi-GPU tasks and result downloads are not implemented.
+scheduler delay remain platform concerns. The shared-storage path does not stream logs or download results. Native
+`fq.submit` retrieves bounded structured results from logs. Automatic resume
+from partial creation and multi-GPU jobs remain unsupported.
 
 Queue detail and job-snapshot endpoints returned 403 for the test account.
 The adapter uses its authorized workspace and job queries instead. Endpoint

--- a/docs/guides/QUAFU_BACKEND.md
+++ b/docs/guides/QUAFU_BACKEND.md
@@ -191,3 +191,5 @@ conversion is deliberately unsupported and fails closed rather than applying
 an incorrect one-qubit approximation. Current Baihua payloads may report zero
 readout fidelities; in that case supply independently measured assignment
 matrices, with task IDs and calibration time retained alongside the result.
+
+For nonblocking Notebook submission and restart recovery, see [remote jobs](REMOTE_JOBS.md).

--- a/docs/guides/REMOTE_JOBS.md
+++ b/docs/guides/REMOTE_JOBS.md
@@ -1,0 +1,89 @@
+# Submit and resume remote jobs
+
+This API requires the development version; it is not in PyPI 0.2.0.
+`fq.run()` still waits for a result. Use `fq.submit()` when a Notebook should
+remain available while a remote task is queued or running. Submission waits only
+for preparation and the provider's acknowledgement, not for execution completion.
+
+## Quafu
+
+Configure `QUAFU_API_TOKEN` in the local environment, then submit once:
+
+```python
+import flagquantum as fq
+
+job = fq.submit(fq.Circuit(2).x(0), target="quafu:Baihua", shots=1024)
+job.save("quafu-job.json")
+print(job.id)
+```
+
+Run a later cell whenever you want to check progress:
+
+```python
+state = job.status()
+print(state, job.raw_status)
+if state == "succeeded":
+    result = job.result()
+    print(result.counts)
+```
+
+`status()` queries once. Normalized states are `queued`, `running`, `succeeded`,
+`failed`, `cancelled`, and `unknown`. Quafu's `Transpiled` means compilation is
+finished and maps to `queued`; it does not mean hardware execution is finished.
+`raw_status` preserves the last queried provider state. Unknown or missing states
+never count as success. Calls still take time for their individual network I/O.
+
+`result()` does not poll: it raises `ExecutionError` unless the job has succeeded.
+To intentionally block the current cell, use `result = job.wait(timeout=600)`.
+A timeout leaves the remote task running. Do not rerun the submission cell to
+check progress. `job.cancel()` requests cancellation; query the state afterwards
+to confirm it. Interrupting a cell or closing a Notebook is not cancellation.
+
+The first detached Quafu journey supports full-register counts. Omit `compiler`
+to use service compilation, or pass `compiler="qsteed"` for local compilation.
+Grouped expectations remain available through `fq.run()`, but are not accepted
+by `submit()` because they can produce several hardware tasks.
+
+## Restore after restarting the Notebook
+
+Keep the receipt private. It contains job identity and decoding context, not
+credentials. It is JSON, not pickle, and saving never overwrites an existing file.
+Configure credentials again after restarting, then run:
+
+```python
+import flagquantum as fq
+
+job = fq.restore_job("quafu-job.json")
+print(job.status())
+```
+
+Restoration never resubmits. A Quafu receipt preserves the submission artifact
+identity, compiler mode, output name and logical bit ordering. Remote results
+remain subject to provider retention and account permissions. Receipt metadata is
+local context, not cryptographic proof of the circuit executed by hardware.
+If submission itself loses its network response, reconcile with the provider
+before retrying: the server may already have accepted the job.
+
+## Jiuding managed batch jobs
+
+The same job methods adapt Jiuding's existing managed program submission:
+
+```python
+job = fq.submit(
+    fq.Circuit(2).h(0).cx(0, 1),
+    target="jiuding:cpu",
+    image="YOUR_FLAGQUANTUM_IMAGE",
+    workspace="YOUR_WORKSPACE",
+)
+job.save("jiuding-job.json")
+```
+
+Choose an image containing the matching FlagQuantum version and configure the
+existing Jiuding credentials and managed workspace transport. This path uses a
+batch job; synchronous `fq.run()` retains its resident-workspace execution path.
+Jiuding restoration resolves the saved job ID in the configured workspace and
+retrieves results through the existing artifact transport. No provider SDK or
+credential object appears in the common user-facing job interface.
+
+No background watcher is started automatically. Manual checks and explicit waits
+are supported; a notebook notification widget is outside this API's scope.

--- a/docs/guides/REMOTE_JOBS.md
+++ b/docs/guides/REMOTE_JOBS.md
@@ -64,26 +64,44 @@ local context, not cryptographic proof of the circuit executed by hardware.
 If submission itself loses its network response, reconcile with the provider
 before retrying: the server may already have accepted the job.
 
-## Jiuding managed batch jobs
+## Jiuding native jobs
 
-The same job methods adapt Jiuding's existing managed program submission:
+Configure `JIUDING_AK` and `JIUDING_SK`, then choose your project, queue and image:
 
 ```python
 job = fq.submit(
     fq.Circuit(2).h(0).cx(0, 1),
-    target="jiuding:cpu",
+    target="jiuding:gpu",
+    project="YOUR_PROJECT_SET.YOUR_PROJECT",
+    queue="YOUR_QUEUE",
     image="YOUR_FLAGQUANTUM_IMAGE",
-    workspace="YOUR_WORKSPACE",
+    outputs=fq.counts(),
+    shots=1024,
 )
 job.save("jiuding-job.json")
+print(job.id)
 ```
 
-Choose an image containing the matching FlagQuantum version and configure the
-existing Jiuding credentials and managed workspace transport. This path uses a
-batch job; synchronous `fq.run()` retains its resident-workspace execution path.
-Jiuding restoration resolves the saved job ID in the configured workspace and
-retrieves results through the existing artifact transport. No provider SDK or
-credential object appears in the common user-facing job interface.
+This path uses native HTTP jobs, without SSH, workspace pods or source uploads.
+The image must contain a compatible FlagQuantum program executor. You can set
+`JIUDING_PROJECT` instead of passing `project`; omit `queue` only when exactly one
+active queue is available. The current adapter requires a queue with one
+high-priority resource configuration and uses its private image catalog.
+Synchronous `fq.run()` retains its resident-workspace execution path.
+
+The circuit is carried in a command bounded to 64 KiB. Results travel through
+chunked authenticated job logs, bounded to 8 MiB and checked for completeness
+and SHA-256 integrity. This is intended for small circuits and compact outputs;
+prefer counts or expectations over large statevectors. Log retention and account
+permissions determine how long results remain retrievable. The checksum detects
+transport corruption; it does not attest hardware execution. Logs may become
+readable shortly after completion; `wait()` retries incomplete results until its
+deadline, while `result()` reports that no result is available yet.
+
+Restore with `fq.restore_job("jiuding-job.json")` in a later process, using the same
+account and endpoint. It retrieves the existing job without resubmitting. If a
+submission response is lost, the exception names a private local journal: inspect
+that experiment before retrying to avoid duplicate jobs.
 
 No background watcher is started automatically. Manual checks and explicit waits
 are supported; a notebook notification widget is outside this API's scope.

--- a/docs/public_api_v1.json
+++ b/docs/public_api_v1.json
@@ -30,8 +30,10 @@
     "experimental",
     "plan",
     "probabilities",
+    "restore_job",
     "run",
     "samples",
+    "submit",
     "train"
   ],
   "verification": {
@@ -65,7 +67,9 @@
     "probabilities": "tests/api_contract/test_observable_outputs.py::test_probability_sample_and_count_outputs",
     "run": "tests/unit/test_module_runtime_contracts.py::test_fq_run_is_the_uniform_execution_entry_point",
     "samples": "tests/api_contract/test_observable_outputs.py::test_probability_sample_and_count_outputs",
-    "train": "tests/api_contract/test_module_training_semantics.py::test_train_is_a_minimal_caller_owned_optimizer_loop"
+    "train": "tests/api_contract/test_module_training_semantics.py::test_train_is_a_minimal_caller_owned_optimizer_loop",
+    "submit": "tests/api_contract/test_remote_jobs.py::test_quafu_submit_result_and_restore",
+    "restore_job": "tests/api_contract/test_remote_jobs.py::test_quafu_submit_result_and_restore"
   },
   "experimental_stability": "none"
 }

--- a/docs/reference/RELEASE_NOTES.md
+++ b/docs/reference/RELEASE_NOTES.md
@@ -17,11 +17,17 @@ Benchmark claims require audited artifacts and are not inferred from this file.
 
 ## Unreleased
 
+- Added `fq.submit()` and `fq.restore_job()` for detached Quafu counts and
+  Jiuding managed program jobs. Jobs support one-shot status/result queries,
+  explicit waits, cancellation requests, and credential-free JSON receipts.
+  Existing synchronous `fq.run()` behavior is unchanged. See
+  [remote jobs](../guides/REMOTE_JOBS.md).
+
 - Added direct Quafu execution through `fq.run(..., target="quafu:Baihua", shots=1024)`
   without a local compiler dependency. The service uses QuarkCircuit compilation;
   explicit `compiler="qsteed"` preserves local precompilation. Counts and grouped
   Pauli expectations share the existing result contract. This path has mocked
-  transport coverage; live service compilation is not yet validated.
+  transport coverage and a limited [Baihua hardware check](../development/evidence/remote_jobs_quafu_20260911.json).
 
 - Renamed the VQE and ADAPT-VQE `optimizer_cls` keyword to
   `optimizer_factory` and published the `flagquantum.algorithms.OptimizerFactory`

--- a/flagquantum/__init__.py
+++ b/flagquantum/__init__.py
@@ -37,6 +37,8 @@ __all__ = (
     "plan",
     "probabilities",
     "run",
+    "submit",
+    "restore_job",
     "samples",
     "train",
     "__version__",
@@ -84,6 +86,8 @@ def __getattr__(name: str) -> Any:
         "samples",
     }:
         return getattr(import_module(".observables", __name__), name)
+    if name in {"submit", "restore_job"}:
+        return getattr(import_module(".remote.jobs", __name__), name)
     if name in {"compile", "plan", "run"}:
         return getattr(import_module("._api", __name__), name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/flagquantum/remote/compute/_job_payload.py
+++ b/flagquantum/remote/compute/_job_payload.py
@@ -1,0 +1,81 @@
+"""Build the platform experiment payload shared by native and workspace jobs."""
+
+from typing import Any
+
+
+def experiment_body(
+    *,
+    command: str,
+    w: dict[str, Any],
+    executable_image: str,
+    image_region: str,
+    model: str,
+    gpus: int,
+    cpus: int,
+    memory_gib: int,
+    run_id: str,
+) -> dict[str, Any]:
+    resource = {
+        "queueId": w["queueId"],
+        "priority": "high",
+        "basicImage": executable_image,
+        "imageRegion": image_region,
+        "clusterId": w["clusterId"],
+        "zoneId": w["zoneId"],
+        "podRestartPolicy": "Never",
+        "restartScope": "FailedInstanceOnly",
+        "roleInfoList": [
+            {
+                "name": "Master",
+                "replicas": 1,
+                "resourceRegion": w["resourceRegion"],
+                "resourceRequestDetail": {
+                    "acceleratorModel": model,
+                    "acceleratorCount": gpus,
+                    "cpuCores": cpus,
+                    "memGib": memory_gib,
+                    "sharedMemGib": 1,
+                    "rdmaSharedCount": 0,
+                },
+            }
+        ],
+    }
+    body = {
+        "projId": w["projId"],
+        "projsetId": w["projsetId"],
+        "name": "flagquantum-" + run_id[:12],
+        "experimentType": "1",
+        "trainFrame": "PyTorch",
+        "creatorId": w["creatorId"],
+        "creator": w["creatorName"],
+        "storageInfo": w["storageInfo"],
+        "heteroType": 1,
+        "advanceConfigInfos": [
+            {
+                "configName": "config1",
+                "codeConfig": "0",
+                "command": command,
+                "hyperParameter": {},
+                "slotsPerWorker": 0,
+                "resourceConfigList": [resource],
+            }
+        ],
+    }
+    body.update(
+        description="",
+        timeType=60000,
+        duration=0,
+        duration1=0,
+        codeConfig="0",
+        createdTime="",
+        delivery=False,
+        mirrorType="",
+        nativeCluster="",
+        restartPolicy="",
+        experimentId="",
+        nameSpace="",
+        profilerInfo={"enabled": False, "level": "typical"},
+        modelStorageInfo={},
+        flag=False,
+    )
+    return body

--- a/flagquantum/remote/compute/_native_job.py
+++ b/flagquantum/remote/compute/_native_job.py
@@ -1,0 +1,313 @@
+"""Jiuding project jobs using HTTP commands and bounded structured log results."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import shlex
+import tempfile
+import time
+import uuid
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from ...core.ir import ensure_circuit_ir
+from ...observables import lower_outputs
+from ...runtime.result import ExecutionResult
+from ._program_job import decode_program_result
+from .jiuding import JiudingClient
+
+_MAX_RESULT = 8 * 1024 * 1024
+_MAX_COMMAND = 64 * 1024
+
+
+def _one(rows: list[dict[str, Any]], name: str, label: str) -> dict[str, Any]:
+    matches = [row for row in rows if row.get("name") == name]
+    if len(matches) != 1:
+        raise ValueError(f"{label} {name!r} did not resolve uniquely")
+    return matches[0]
+
+
+def _command(request: dict[str, Any], run_id: str) -> str:
+    """Encode data as an argument; never interpolate user data into Python code."""
+    encoded = base64.b64encode(json.dumps(request, allow_nan=False).encode()).decode()
+    code = """import base64,hashlib,json,sys
+from flagquantum.remote.compute._workspace_executor import execute
+p=json.loads(base64.b64decode(sys.argv[1]))
+r=execute(p,target=p["target"],device="cuda:0" if p["target"].startswith("jiuding:gpu/") else "cpu")
+if r.get("ok") is not True:
+    raise RuntimeError(r.get("message","FlagQuantum execution failed"))
+b=json.dumps(r,allow_nan=False,separators=(",",":")).encode()
+if len(b)>8388608: raise RuntimeError("Result exceeds the 8 MiB job log transport limit")
+s=base64.b64encode(b).decode(); chunks=[s[i:i+3072] for i in range(0,len(s),3072)]
+h=hashlib.sha256(b).hexdigest()
+for i,chunk in enumerate(chunks):
+    print("FQ_RESULT_"+sys.argv[2]+" "+str(i)+"/"+str(len(chunks))+" "+h+" "+chunk,flush=True)
+"""
+    command = shlex.join(["python", "-u", "-c", code, encoded, run_id])
+    if len(command.encode()) > _MAX_COMMAND:
+        raise ValueError("Circuit exceeds the 64 KiB inline job command limit")
+    return command
+
+
+def _decode_lines(lines: list[str], run_id: str) -> dict[str, Any]:
+    prefix = f"FQ_RESULT_{run_id} "
+    chunks: dict[int, str] = {}
+    identity: tuple[int, str] | None = None
+    for line in lines:
+        if not line.startswith(prefix):
+            continue
+        try:
+            index_count, digest, content = line[len(prefix) :].split(" ", 2)
+            index, count = map(int, index_count.split("/"))
+        except (ValueError, TypeError) as exc:
+            raise RuntimeError("Malformed job result chunk") from exc
+        if not 0 <= index < count <= 4096 or len(content) > 3072:
+            raise RuntimeError("Job result chunk exceeds transport bounds")
+        if identity is not None and identity != (count, digest):
+            raise RuntimeError("Conflicting job result identities")
+        identity = (count, digest)
+        if index in chunks and chunks[index] != content:
+            raise RuntimeError("Conflicting job result chunks")
+        chunks[index] = content
+    if identity is None or len(chunks) != identity[0]:
+        raise RuntimeError("Jiuding job has no result yet; log chunks are incomplete")
+    encoded = "".join(chunks[index] for index in range(identity[0]))
+    data = base64.b64decode(encoded, validate=True)
+    if len(data) > _MAX_RESULT or hashlib.sha256(data).hexdigest() != identity[1]:
+        raise RuntimeError("Jiuding result size or digest mismatch")
+    value = json.loads(data)
+    if not isinstance(value, dict):
+        raise RuntimeError("Jiuding result must be a JSON object")
+    return value
+
+
+class NativeJiudingJobClient(JiudingClient):
+    """Reuse the job HTTP transport, resolving context from projects, not pods."""
+
+    def __init__(self, *, project: str, queue: str | None = None) -> None:
+        super().__init__()
+        parts = project.split(".")
+        if len(parts) != 2 or not all(parts):
+            raise ValueError("project must use 'project-set.project' notation")
+        self.project = project
+        self.queue = queue
+        self._context: dict[str, Any] | None = None
+
+    def workspace(self) -> dict[str, Any]:
+        """Supply project/queue context to existing HTTP helpers; never access a pod."""
+        if self._context is not None:
+            return dict(self._context)
+        auth = self._auth()
+        user = self._request("/api/v1/users/token/userinfo", None, auth, method="GET")[
+            "data"
+        ]
+        sets = self._request("/api/v1/projsets/select-joined", {}, auth)["items"]
+        set_name, project_name = self.project.split(".")
+        project_set = _one([x["projsetInfo"] for x in sets], set_name, "Project set")
+        projects = self._request(
+            "/api/v1/projects/select-joined", {"projsetId": project_set["id"]}, auth
+        )["items"]
+        project = _one([x["projInfo"] for x in projects], project_name, "Project")
+        headers = {
+            **auth,
+            "x-user-id": str(user["id"]),
+            "AIRS-Proj-ID": project["id"],
+            "AIRS-Projset-ID": project_set["id"],
+        }
+        queues = list(
+            self._pages(
+                "/api/v1/queue/select",
+                {
+                    "projId": project["id"],
+                    "projsetId": project_set["id"],
+                    "as_user": True,
+                    "userId": str(user["id"]),
+                },
+                "queueSummaryInfos",
+                headers,
+            )
+        )
+        active = [q for q in queues if q.get("status") == "QUEUE_STATUS_ACTIVE"]
+        if self.queue is None:
+            if len(active) != 1:
+                raise ValueError(
+                    "Specify queue; active choices: "
+                    + ", ".join(q["name"] for q in active)
+                )
+            selected = active[0]
+        else:
+            selected = _one(active, self.queue, "Queue")
+        configs = [
+            (cluster, zone, quota)
+            for cluster in selected["quotaInfoList"]
+            for zone in cluster["zoneQuotaInfoList"]
+            for quota in zone["quotaMetaList"]
+            if quota.get("priority") == "high"
+        ]
+        if len(configs) != 1:
+            raise ValueError(
+                "Queue must resolve one high-priority resource configuration"
+            )
+        cluster, zone, quota = configs[0]
+        self._context = {
+            "name": self.project,
+            "projId": project["id"],
+            "projsetId": project_set["id"],
+            "queueId": selected["id"],
+            "queueName": selected["name"],
+            "queueStatus": selected["status"],
+            "clusterId": cluster["clusterId"],
+            "zoneId": zone["zoneId"],
+            "clusterName": cluster["clusterName"],
+            "resourceRegion": "ACCELERATOR_SUITE",
+            "creatorId": str(user["id"]),
+            "creatorName": user.get("alias", ""),
+            "storageInfo": [],
+            "acceleratorModel": quota["resourceDetail"].get("acceleratorModel", ""),
+        }
+        return dict(self._context)
+
+    def submit_program(
+        self,
+        program: Any,
+        *,
+        target: str,
+        image: str,
+        outputs: Any = None,
+        shots: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if kwargs:
+            raise TypeError("Unsupported native job options: " + ", ".join(kwargs))
+        ir = ensure_circuit_ir(program)
+        if outputs is None and shots is not None:
+            raise TypeError("shots requires an explicit sampling output")
+        measurements = (
+            lower_outputs(outputs, n_wires=ir.n_wires, shots=shots)
+            if outputs is not None
+            else ()
+        )
+        ir = replace(ir, measurements=measurements or ())
+        w = self.workspace()
+        chip, model = self._resolve_compute_target(target)
+        selected = f"jiuding:gpu/{model}" if chip == "gpu" else "jiuding:cpu"
+        from ._workspace_executor import SCHEMA, VERSION
+
+        run_id = uuid.uuid4().hex
+        command = _command(
+            {
+                "schema": SCHEMA,
+                "version": VERSION,
+                "operation": "measurements" if outputs is not None else "statevector",
+                "request_id": "batch-program",
+                "target": selected,
+                "program": ir.to_dict(),
+            },
+            run_id,
+        )
+        catalog = self._catalog_image(image, "PRIVATE")
+        executable = catalog.get("registryUrl")
+        if not isinstance(executable, str) or not executable:
+            raise ValueError("Image has no executable registry URL")
+        # Preflight the same authenticated log service used for result retrieval.
+        datasource = self._request(
+            "/grafana/api/datasources/name/"
+            + quote("log." + w["clusterName"], safe=""),
+            None,
+            self._auth(),
+            method="GET",
+        )
+        if datasource.get("type") != "loki" or not isinstance(
+            datasource.get("uid"), str
+        ):
+            raise RuntimeError("Expected the platform Loki job log datasource")
+        receipt = Path(tempfile.mkdtemp(prefix="flagquantum-job-")) / "receipt.json"
+        record = {
+            "run_id": run_id,
+            "experimentName": "flagquantum-" + run_id[:12],
+            "endpoint": self.endpoint,
+            "queueId": w["queueId"],
+            "submission": "unknown",
+            "project": self.project,
+            "queue": w["queueName"],
+            "receipt": str(receipt),
+            "requested_target": target,
+            "selected_target": selected,
+            "artifact_transport": "job_logs",
+            "datasource_uid": datasource["uid"],
+            "created_ms": int(time.time() * 1000),
+        }
+        try:
+            return self._launch_command(
+                command=command,
+                w=w,
+                executable_image=executable,
+                image_region="PRIVATE",
+                model=model,
+                gpus=int(chip == "gpu"),
+                cpus=2,
+                memory_gib=2,
+                run_id=run_id,
+                receipt=receipt,
+                record=record,
+            )
+        except Exception as exc:
+            # The journal records whether creation/launch may already have happened.
+            raise RuntimeError(
+                f"Native job submission stopped; inspect {receipt} before retrying"
+            ) from exc
+
+    def read_result(self, receipt: dict[str, Any]) -> ExecutionResult:
+        if (
+            receipt.get("project") != self.project
+            or receipt.get("endpoint") != self.endpoint
+        ):
+            raise ValueError("Job receipt belongs to another project or endpoint")
+        job_id = str(uuid.UUID(receipt["jobId"]))
+        run_id = uuid.UUID(hex=receipt["run_id"]).hex
+        if self.workspace()["queueId"] != receipt["queueId"]:
+            raise ValueError("Job receipt belongs to another queue")
+        response = self._request(
+            "/grafana/api/ds/query",
+            {
+                "from": str(receipt["created_ms"] - 60000),
+                "to": str(int(time.time() * 1000)),
+                "queries": [
+                    {
+                        "refId": "A",
+                        "datasource": {
+                            "type": "loki",
+                            "uid": receipt["datasource_uid"],
+                        },
+                        "expr": '{namespace="airs", app=~"job-'
+                        + job_id
+                        + '.*"} |= "FQ_RESULT_'
+                        + run_id
+                        + ' "',
+                        "queryType": "range",
+                        "maxLines": 4096,
+                        "direction": "forward",
+                    }
+                ],
+            },
+            self._auth(),
+        )
+        result = response.get("results", {}).get("A", {})
+        if result.get("error") or result.get("status") != 200:
+            raise RuntimeError("Jiuding job log query did not succeed")
+        lines = []
+        for frame in result.get("frames", []):
+            fields = frame["schema"]["fields"]
+            for index, field in enumerate(fields):
+                if field.get("name") == "Line":
+                    lines.extend(frame["data"]["values"][index])
+        value = _decode_lines(lines, run_id)
+        return decode_program_result(
+            value,
+            requested_target=receipt["requested_target"],
+            selected_target=receipt["selected_target"],
+        )

--- a/flagquantum/remote/compute/jiuding.py
+++ b/flagquantum/remote/compute/jiuding.py
@@ -997,72 +997,9 @@ class JiudingClient(_ProgramSubmissionMixin):
             if not root.is_dir():
                 raise ValueError("pythonpath must be a shared source directory")
             command = "env " + shlex.quote("PYTHONPATH=" + str(root)) + " " + command
-        resource = {
-            "queueId": w["queueId"],
-            "priority": "high",
-            "basicImage": executable_image,
-            "imageRegion": image_region,
-            "clusterId": w["clusterId"],
-            "zoneId": w["zoneId"],
-            "podRestartPolicy": "Never",
-            "restartScope": "FailedInstanceOnly",
-            "roleInfoList": [
-                {
-                    "name": "Master",
-                    "replicas": 1,
-                    "resourceRegion": w["resourceRegion"],
-                    "resourceRequestDetail": {
-                        "acceleratorModel": model,
-                        "acceleratorCount": gpus,
-                        "cpuCores": cpus,
-                        "memGib": memory_gib,
-                        "sharedMemGib": 1,
-                        "rdmaSharedCount": 0,
-                    },
-                }
-            ],
-        }
-        body = {
-            "projId": w["projId"],
-            "projsetId": w["projsetId"],
-            "name": "flagquantum-" + run_id[:12],
-            "experimentType": "1",
-            "trainFrame": "PyTorch",
-            "creatorId": w["creatorId"],
-            "creator": w["creatorName"],
-            "storageInfo": w["storageInfo"],
-            "heteroType": 1,
-            "advanceConfigInfos": [
-                {
-                    "configName": "config1",
-                    "codeConfig": "0",
-                    "command": command,
-                    "hyperParameter": {},
-                    "slotsPerWorker": 0,
-                    "resourceConfigList": [resource],
-                }
-            ],
-        }
-        body.update(
-            description="",
-            timeType=60000,
-            duration=0,
-            duration1=0,
-            codeConfig="0",
-            createdTime="",
-            delivery=False,
-            mirrorType="",
-            nativeCluster="",
-            restartPolicy="",
-            experimentId="",
-            nameSpace="",
-            profilerInfo={"enabled": False, "level": "typical"},
-            modelStorageInfo={},
-            flag=False,
-        )
         record = {
             "run_id": run_id,
-            "experimentName": body["name"],
+            "experimentName": "flagquantum-" + run_id[:12],
             "entrypoint": str(script),
             "endpoint": self.endpoint,
             "queueId": w["queueId"],
@@ -1078,6 +1015,49 @@ class JiudingClient(_ProgramSubmissionMixin):
                 "accelerator_model": model,
             },
         }
+        return self._launch_command(
+            command=command,
+            w=w,
+            executable_image=executable_image,
+            image_region=image_region,
+            model=model,
+            gpus=gpus,
+            cpus=cpus,
+            memory_gib=memory_gib,
+            run_id=run_id,
+            receipt=receipt,
+            record=record,
+        )
+
+    def _launch_command(
+        self,
+        *,
+        command: str,
+        w: dict[str, Any],
+        executable_image: str,
+        image_region: str,
+        model: str,
+        gpus: int,
+        cpus: int,
+        memory_gib: int,
+        run_id: str,
+        receipt: Path,
+        record: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Create and launch one journaled experiment using its command and resources."""
+        from ._job_payload import experiment_body
+
+        body = experiment_body(
+            command=command,
+            w=w,
+            executable_image=executable_image,
+            image_region=image_region,
+            model=model,
+            gpus=gpus,
+            cpus=cpus,
+            memory_gib=memory_gib,
+            run_id=run_id,
+        )
         with receipt.open("x") as file:
             json.dump(record, file)
         created = self._request("/api/v1/experiment", body, self._headers())

--- a/flagquantum/remote/jobs.py
+++ b/flagquantum/remote/jobs.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from ..errors import CapabilityError, ExecutionError
 from ..runtime.result import ExecutionResult
+from .compute._native_job import NativeJiudingJobClient
 from .compute.jiuding import JiudingClient
 from .qpu.contracts import (
     ProviderTaskHandle,
@@ -40,6 +41,7 @@ class _Receipt:
     output_name: str | None = None
     workspace: str | None = None
     submission_identity: dict[str, str] = field(default_factory=dict)
+    native_receipt: dict[str, Any] | None = None
     schema: str = "flagquantum.remote-job.v1"
 
 
@@ -148,6 +150,9 @@ class RemoteJob:
                 target_qubits=r.target_qubits,
                 name=r.name,
             )
+        if isinstance(self._client, NativeJiudingJobClient):
+            return self._client.read_result(self._jiuding_receipt())
+
         from .compute._managed_program import read_managed_result
         from .compute._program_submission import decode_job_result
 
@@ -176,7 +181,7 @@ class RemoteJob:
                 try:
                     return self.result()
                 except RuntimeError as exc:
-                    # Quafu may mark completion before its result endpoint is ready.
+                    # Providers may report completion before results become readable.
                     if "has no result yet" not in str(exc):
                         raise
             if state in {"failed", "cancelled"}:
@@ -225,10 +230,12 @@ def submit(
     name: str | None = None,
     image: str | None = None,
     workspace: str | None = None,
+    project: str | None = None,
+    queue: str | None = None,
 ) -> RemoteJob:
     """Submit once and return without waiting for remote execution.
 
-    Quafu supports full-register counts. Jiuding uses managed batch execution and
+    Quafu supports full-register counts. Jiuding uses native HTTP batch execution and
     requires an image; credentials come from the existing provider configuration.
     Submission includes preparation and network I/O. Unsupported output requests
     fail before a task is submitted. Save the returned job for later restoration.
@@ -246,20 +253,26 @@ def submit(
             )
         if not isinstance(image, str) or not image.strip():
             raise ValueError("Jiuding batch submission requires image")
-        selected_workspace = workspace or os.environ.get("JIUDING_WORKSPACE") or None
-        client = JiudingClient(workspace=selected_workspace)
+        if workspace is not None:
+            raise TypeError("Native jobs use project and queue, not workspace")
+        selected_project = project or os.environ.get("JIUDING_PROJECT")
+        if not selected_project:
+            raise ValueError(
+                "Jiuding submission requires project='project-set.project'"
+            )
+        client = NativeJiudingJobClient(project=selected_project, queue=queue)
         native = client.submit_program(
             ir, target=target, image=image, outputs=outputs, shots=shots
         )
         return RemoteJob(
-            _Receipt(
-                str(native["jobId"]), target, ir.n_wires, workspace=selected_workspace
-            ),
+            _Receipt(str(native["jobId"]), target, ir.n_wires, native_receipt=native),
             client,
             native,
         )
-    if image is not None or workspace is not None:
-        raise TypeError("image and workspace apply only to Jiuding submission")
+    if any(value is not None for value in (image, workspace, project, queue)):
+        raise TypeError(
+            "image, project, queue and workspace apply only to Jiuding submission"
+        )
     return _submit_quafu(
         ir,
         target=target,
@@ -389,6 +402,23 @@ def restore_job(path: str | Path) -> RemoteJob:
             receipt, QuafuProvider(reverse_result_bits=receipt.compiler is None)
         )
     if provider == "jiuding":
+        native = receipt.native_receipt
+        if native is not None:
+            if (
+                not isinstance(native, dict)
+                or native.get("jobId") != receipt.id
+                or native.get("artifact_transport") != "job_logs"
+                or not isinstance(native.get("project"), str)
+                or not isinstance(native.get("queue"), str)
+            ):
+                raise ValueError("Invalid native job receipt")
+            return RemoteJob(
+                receipt,
+                NativeJiudingJobClient(
+                    project=native["project"], queue=native["queue"]
+                ),
+                native,
+            )
         return RemoteJob(receipt, JiudingClient(workspace=receipt.workspace))
     raise ValueError("Unsupported receipt provider")
 

--- a/flagquantum/remote/jobs.py
+++ b/flagquantum/remote/jobs.py
@@ -1,0 +1,396 @@
+"""Detached remote jobs with explicit polling and credential-free receipts."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from ..errors import CapabilityError, ExecutionError
+from ..runtime.result import ExecutionResult
+from .compute.jiuding import JiudingClient
+from .qpu.contracts import (
+    ProviderTaskHandle,
+    build_result_metadata,
+    validate_deployment_result,
+)
+from .qpu.quafu import QuafuProvider
+
+if TYPE_CHECKING:
+    from ..circuit import Circuit
+    from ..core.ir import CircuitIR
+    from ..observables import OutputRequest
+
+JobStatus = Literal["queued", "running", "succeeded", "failed", "cancelled", "unknown"]
+
+
+@dataclass(frozen=True)
+class _Receipt:
+    id: str
+    target: str
+    n_wires: int
+    compiler: str | None = None
+    target_qubits: tuple[int, ...] = ()
+    name: str | None = None
+    output_name: str | None = None
+    workspace: str | None = None
+    submission_identity: dict[str, str] = field(default_factory=dict)
+    schema: str = "flagquantum.remote-job.v1"
+
+
+def _normalize(raw: str) -> JobStatus:
+    value = raw.lower()
+    if value in {"finished", "completed", "done", "succeed", "succeeded"}:
+        return "succeeded"
+    if value in {"failed", "error"}:
+        return "failed"
+    if value in {"cancelled", "canceled", "stopped"}:
+        return "cancelled"
+    if value in {
+        "queued",
+        "pending",
+        "scheduling",
+        "starting",
+        "transpiled",
+        "waiting",
+    }:
+        return "queued"
+    if value in {"running", "executing", "transpiling"}:
+        return "running"
+    return "unknown"
+
+
+class RemoteJob:
+    """One remotely submitted job; obtain through submit or restore_job.
+
+    No method resubmits a job. Status and result calls may wait for network I/O,
+    but only wait() polls for execution completion. raw_status holds the last
+    queried provider status, or None before the first query.
+    """
+
+    def __init__(
+        self,
+        receipt: _Receipt,
+        client: QuafuProvider | JiudingClient,
+        native_receipt: dict[str, Any] | None = None,
+    ) -> None:
+        self._receipt = receipt
+        self._client = client
+        self._native_receipt = native_receipt
+        self._raw_status: str | None = None
+
+    @property
+    def id(self) -> str:
+        return self._receipt.id
+
+    @property
+    def target(self) -> str:
+        return self._receipt.target
+
+    @property
+    def raw_status(self) -> str | None:
+        return self._raw_status
+
+    def _handle(self) -> ProviderTaskHandle:
+        return ProviderTaskHandle(
+            "quafu",
+            self.id,
+            self.target.partition(":")[2],
+            self._receipt.submission_identity,
+        )
+
+    def _jiuding_receipt(self) -> dict[str, Any]:
+        assert isinstance(self._client, JiudingClient)
+        if self._native_receipt is None:
+            self._native_receipt = self._client.restore_receipt(self.id)
+        return self._native_receipt
+
+    def status(self) -> JobStatus:
+        """Query once and normalize state; unrecognized states remain unknown."""
+        if isinstance(self._client, QuafuProvider):
+            self._raw_status = self._client.query_status(self._handle())
+            return _normalize(self._raw_status)
+        jobs = self._client.status(self._jiuding_receipt())
+        # An experiment may have previous attempts: inspect the submitted job only.
+        states = [str(j.get("status", "")) for j in jobs if str(j.get("id")) == self.id]
+        self._raw_status = ", ".join(states) if states else "Missing"
+        return _normalize(states[0]) if len(states) == 1 else "unknown"
+
+    def result(self) -> ExecutionResult:
+        """Fetch a finished result once; raise ExecutionError when not successful."""
+        state = self.status()
+        if state != "succeeded":
+            raise ExecutionError(
+                f"Job {self.id} is {state} ({self.raw_status}); no result fetched"
+            )
+        if isinstance(self._client, QuafuProvider):
+            from .qpu.execution import counts_result
+
+            native = validate_deployment_result(
+                self._client.fetch_result(self._handle())
+            )
+            r = self._receipt
+            if any(len(str(key)) != r.n_wires for key in native.counts):
+                raise ExecutionError(
+                    "Returned count width differs from the submitted circuit"
+                )
+            return counts_result(
+                native,
+                n_wires=r.n_wires,
+                output_name=r.output_name,
+                compiler=r.compiler,
+                target=r.target,
+                target_qubits=r.target_qubits,
+                name=r.name,
+            )
+        from .compute._managed_program import read_managed_result
+        from .compute._program_submission import decode_job_result
+
+        receipt = self._jiuding_receipt()
+        value = decode_job_result(read_managed_result(self._client, receipt), receipt)
+        if not isinstance(value, ExecutionResult):
+            raise ExecutionError("Jiuding program did not return an ExecutionResult")
+        return value
+
+    def wait(
+        self, timeout: float = 300.0, poll_interval: float = 3.0
+    ) -> ExecutionResult:
+        """Poll until completion; timeout leaves the remote job running.
+
+        The deadline bounds polling; an in-flight network request is additionally
+        bounded by its provider timeout. No background thread is started.
+        """
+        if not math.isfinite(timeout) or timeout < 0:
+            raise ValueError("timeout must be finite and nonnegative")
+        if not math.isfinite(poll_interval) or poll_interval <= 0:
+            raise ValueError("poll_interval must be finite and positive")
+        deadline = time.monotonic() + timeout
+        while True:
+            state = self.status()
+            if state == "succeeded":
+                try:
+                    return self.result()
+                except RuntimeError as exc:
+                    # Quafu may mark completion before its result endpoint is ready.
+                    if "has no result yet" not in str(exc):
+                        raise
+            if state in {"failed", "cancelled"}:
+                raise ExecutionError(f"Job {self.id} is {state} ({self.raw_status})")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Job {self.id} is not complete; no cancellation or resubmission"
+                )
+            time.sleep(min(poll_interval, remaining))
+
+    def cancel(self) -> None:
+        """Request cancellation; query status to confirm the remote outcome."""
+        if isinstance(self._client, QuafuProvider):
+            self._client.cancel(self._handle())
+        else:
+            receipt = self._jiuding_receipt()
+            attempts = self._client.status(receipt)
+            if any(
+                str(attempt.get("id")) != self.id
+                and _normalize(str(attempt.get("status", "")))
+                not in {"succeeded", "failed", "cancelled"}
+                for attempt in attempts
+            ):
+                raise CapabilityError(
+                    "Jiuding experiment has other active attempts; cancel through the provider"
+                )
+            self._client.cancel(receipt)
+
+    def save(self, path: str | Path) -> None:
+        """Save a private JSON receipt without credentials; never overwrite a file."""
+        encoded = json.dumps(asdict(self._receipt), indent=2) + "\n"
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(encoded)
+
+
+def submit(
+    program: Circuit | CircuitIR,
+    *,
+    target: str,
+    outputs: OutputRequest | Sequence[OutputRequest] | None = None,
+    shots: int | None = None,
+    compiler: str | None = None,
+    target_qubits: Sequence[int] | None = None,
+    name: str | None = None,
+    image: str | None = None,
+    workspace: str | None = None,
+) -> RemoteJob:
+    """Submit once and return without waiting for remote execution.
+
+    Quafu supports full-register counts. Jiuding uses managed batch execution and
+    requires an image; credentials come from the existing provider configuration.
+    Submission includes preparation and network I/O. Unsupported output requests
+    fail before a task is submitted. Save the returned job for later restoration.
+    """
+    from ..core.ir import ensure_circuit_ir
+
+    ir = ensure_circuit_ir(program)
+    provider, separator, backend = target.partition(":")
+    if not separator or not backend.strip() or provider not in {"quafu", "jiuding"}:
+        raise ValueError("target must name a quafu or jiuding backend")
+    if provider == "jiuding":
+        if compiler is not None or target_qubits is not None or name is not None:
+            raise TypeError(
+                "Jiuding submission does not accept compiler, target_qubits or name"
+            )
+        if not isinstance(image, str) or not image.strip():
+            raise ValueError("Jiuding batch submission requires image")
+        selected_workspace = workspace or os.environ.get("JIUDING_WORKSPACE") or None
+        client = JiudingClient(workspace=selected_workspace)
+        native = client.submit_program(
+            ir, target=target, image=image, outputs=outputs, shots=shots
+        )
+        return RemoteJob(
+            _Receipt(
+                str(native["jobId"]), target, ir.n_wires, workspace=selected_workspace
+            ),
+            client,
+            native,
+        )
+    if image is not None or workspace is not None:
+        raise TypeError("image and workspace apply only to Jiuding submission")
+    return _submit_quafu(
+        ir,
+        target=target,
+        outputs=outputs,
+        shots=shots,
+        compiler=compiler,
+        target_qubits=target_qubits,
+        name=name,
+    )
+
+
+def _submit_quafu(
+    ir: CircuitIR,
+    *,
+    target: str,
+    outputs: OutputRequest | Sequence[OutputRequest] | None,
+    shots: int | None,
+    compiler: str | None,
+    target_qubits: Sequence[int] | None,
+    name: str | None,
+) -> RemoteJob:
+    from ..deployment import CloudBackendProfile, create_deployment_package
+    from .qpu.execution import validate_quafu_output
+    from .qpu.quafu import _service_options
+
+    output = validate_quafu_output(ir, outputs)
+    if output.kind != "counts":
+        raise CapabilityError(
+            "Detached Quafu jobs support full-register counts; use fq.run for expectations"
+        )
+    if type(shots) is not int or shots <= 0 or shots % 1024:
+        raise ValueError("Quafu shots must be a positive multiple of 1024")
+    if name is not None and (not isinstance(name, str) or not name.strip()):
+        raise ValueError("name must be a non-empty string")
+    package_options: dict[str, Any] = {}
+    if compiler is None:
+        if ir.metadata.get("execution_target"):
+            raise ValueError("service compilation requires an unbound logical circuit")
+        options = _service_options(
+            ir.n_wires, () if target_qubits is None else target_qubits
+        )
+        package_options = {
+            "backend": CloudBackendProfile(
+                provider="quafu",
+                name=target.partition(":")[2].strip(),
+                n_wires=ir.n_wires,
+            ),
+            "optimize": False,
+            "metadata": {
+                "provider_options": options,
+                "compilation_location": "service",
+                "service_compiler": "quarkcircuit",
+            },
+        }
+        mapping = tuple(options["target_qubits"])
+    else:
+        from .._api import compile
+
+        ir = compile(ir, compiler=compiler, target=target, target_qubits=target_qubits)
+        mapping = tuple(
+            ir.metadata.get("execution_target", {}).get("target_qubits", ())
+        )
+    package = create_deployment_package(
+        ir,
+        shots=shots,
+        name=name.strip() if name else "flagquantum_job",
+        **package_options,
+    )
+    client = QuafuProvider(reverse_result_bits=compiler is None)
+    handle = client.submit(package)
+    return RemoteJob(
+        _Receipt(
+            handle.task_id,
+            target,
+            ir.n_wires,
+            compiler,
+            mapping,
+            name,
+            output.name,
+            submission_identity=build_result_metadata(handle),
+        ),
+        client,
+    )
+
+
+def restore_job(path: str | Path) -> RemoteJob:
+    """Reconnect using a saved receipt; never submit or deserialize executable code."""
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or raw.get("schema") != "flagquantum.remote-job.v1":
+        raise ValueError("Unsupported remote job receipt schema")
+    try:
+        receipt = _Receipt(**raw)
+    except TypeError as exc:
+        raise ValueError("Invalid remote job receipt fields") from exc
+    if not isinstance(receipt.id, str) or not receipt.id.strip():
+        raise ValueError("Receipt must contain a job ID")
+    if type(receipt.n_wires) is not int or receipt.n_wires <= 0:
+        raise ValueError("Receipt must contain a positive circuit width")
+    if not isinstance(receipt.target, str):
+        raise ValueError("Invalid receipt target")
+    for value in (
+        receipt.compiler,
+        receipt.name,
+        receipt.output_name,
+        receipt.workspace,
+    ):
+        if value is not None and not isinstance(value, str):
+            raise ValueError("Invalid receipt text field")
+    from .qpu.quafu import _service_options
+
+    _service_options(receipt.n_wires, receipt.target_qubits)
+    provider, separator, backend = receipt.target.partition(":")
+    if not separator or not backend.strip():
+        raise ValueError("Invalid receipt target")
+    if provider == "quafu":
+        if not isinstance(receipt.submission_identity, dict) or any(
+            not isinstance(k, str) or not isinstance(v, str)
+            for k, v in receipt.submission_identity.items()
+        ):
+            raise ValueError("Invalid submission identity")
+        build_result_metadata(
+            ProviderTaskHandle(
+                "quafu", receipt.id, backend, receipt.submission_identity
+            )
+        )
+        return RemoteJob(
+            receipt, QuafuProvider(reverse_result_bits=receipt.compiler is None)
+        )
+    if provider == "jiuding":
+        return RemoteJob(receipt, JiudingClient(workspace=receipt.workspace))
+    raise ValueError("Unsupported receipt provider")
+
+
+__all__ = ("JobStatus", "RemoteJob", "restore_job", "submit")

--- a/flagquantum/remote/qpu/execution.py
+++ b/flagquantum/remote/qpu/execution.py
@@ -15,6 +15,7 @@ from ...deployment import (
 from ...observables import OutputRequest
 from ...observables import counts as request_counts
 from ...runtime.result import ExecutionResult, MeasurementResult
+from .contracts import DeploymentResult
 from .quafu import QuafuProvider, _service_options
 
 if TYPE_CHECKING:
@@ -255,26 +256,49 @@ def _execute_counts(
         native = deploy_circuit(
             compiled, provider, shots=shots, name=name.strip(), **package_options
         )
+    return counts_result(
+        native,
+        n_wires=compiled.n_wires,
+        output_name=output.name,
+        compiler=compiler,
+        target=target,
+        target_qubits=tuple(
+            (
+                compiled.metadata.get("execution_target", {})
+                if compiler is not None
+                else package_options["metadata"]["provider_options"]
+            ).get("target_qubits", ())
+        ),
+        name=name,
+    )
+
+
+def counts_result(
+    native: DeploymentResult,
+    *,
+    n_wires: int,
+    output_name: str | None,
+    compiler: str | None,
+    target: str,
+    target_qubits: Sequence[int],
+    name: str | None,
+) -> ExecutionResult:
+    """Normalize one provider result for synchronous and detached jobs."""
     counts: dict[str | int, int] = {
         str(key): int(value) for key, value in native.counts.items()
     }
-    execution_target = (
-        compiled.metadata.get("execution_target", {})
-        if compiler is not None
-        else package_options["metadata"]["provider_options"]
-    )
     result = ExecutionResult(
         measurements=(
             MeasurementResult(
                 kind="counts",
-                wires=tuple(range(compiled.n_wires)),
+                wires=tuple(range(n_wires)),
                 value=[counts],
                 shots=native.shots,
                 metadata={
                     "fq_output_index": 0,
                     "fq_output_kind": "counts",
-                    "fq_output_name": output.name,
-                    **({"name": output.name} if output.name is not None else {}),
+                    "fq_output_name": output_name,
+                    **({"name": output_name} if output_name is not None else {}),
                     "provider": native.handle.provider,
                     "backend": native.handle.backend_name,
                     "task_id": native.handle.task_id,
@@ -287,7 +311,7 @@ def _execute_counts(
             "task_id": native.handle.task_id,
             "compiler": compiler,
             "target": target,
-            "target_qubits": tuple(execution_target.get("target_qubits", ())),
+            "target_qubits": tuple(target_qubits),
             **(
                 {
                     "compilation_location": "service",

--- a/tests/api_contract/test_remote_jobs.py
+++ b/tests/api_contract/test_remote_jobs.py
@@ -1,0 +1,266 @@
+"""Detached jobs remain resumable and never resubmit during observation."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+import flagquantum as fq
+from flagquantum.errors import CapabilityError, ExecutionError
+from flagquantum.remote import jobs
+from flagquantum.remote.qpu.quafu import QuafuProvider
+
+
+class Transport:
+    def __init__(self):
+        self.posts = []
+        self.gets = []
+        self.state = "Transpiled"
+
+    def post_json(self, url, payload, headers, timeout):
+        self.posts.append(payload)
+        return {"task_id": "job-123"}
+
+    def get_json(self, url, headers, timeout):
+        self.gets.append(url)
+        if "/status/" in url:
+            return self.state
+        if "/result/" in url:
+            return {"count": {"01": 1000, "00": 24}, "transpiled": "physical circuit"}
+        if "/cancel/" in url:
+            self.state = "Cancelled"
+            return {}
+        raise AssertionError(url)
+
+
+@pytest.fixture
+def quafu(monkeypatch):
+    transport = Transport()
+
+    class Client(QuafuProvider):
+        def __init__(self, **kwargs):
+            super().__init__(token="test-private-token", transport=transport, **kwargs)
+
+    monkeypatch.setattr(jobs, "QuafuProvider", Client)
+    return transport
+
+
+def test_quafu_submit_result_and_restore(quafu, tmp_path):
+    job = fq.submit(
+        fq.Circuit(2).x(0),
+        target="quafu:Baihua",
+        shots=1024,
+        outputs=fq.counts(name="readout"),
+    )
+    assert job.id == "job-123"
+    assert job.target == "quafu:Baihua"
+    assert quafu.gets == []
+    assert job.status() == "queued"
+    assert job.raw_status == "Transpiled"
+    with pytest.raises(ExecutionError, match="queued"):
+        job.result()
+    assert not any("/result/" in url for url in quafu.gets)
+    receipt = tmp_path / "job.json"
+    job.save(receipt)
+    assert "test-private-token" not in receipt.read_text()
+    assert receipt.stat().st_mode & 0o777 == 0o600
+    with pytest.raises(FileExistsError):
+        job.save(receipt)
+    restored = fq.restore_job(receipt)
+    assert len(quafu.posts) == 1
+    quafu.state = "Finished"
+    result = restored.result()
+    assert result.counts == [{"10": 1000, "00": 24}]
+    assert result.measurements[0].metadata["name"] == "readout"
+    assert result.provenance["service_compiler"] == "quarkcircuit"
+    assert len(quafu.posts) == 1
+
+
+def test_wait_cancel_and_unknown_state(quafu):
+    job = fq.submit(fq.Circuit(2), target="quafu:Baihua", shots=1024)
+    quafu.state = "UnrecognizedProviderState"
+    assert job.status() == "unknown"
+    with pytest.raises(TimeoutError, match="no cancellation"):
+        job.wait(timeout=0)
+    assert len(quafu.posts) == 1
+    assert not any("/cancel/" in url for url in quafu.gets)
+    job.cancel()
+    assert job.status() == "cancelled"
+    with pytest.raises(ExecutionError, match="cancelled"):
+        job.wait(timeout=1)
+    quafu.state = "Failed"
+    with pytest.raises(ExecutionError, match="failed"):
+        job.result()
+    quafu.state = "Finished"
+    assert job.wait(timeout=0).counts == [{"10": 1000, "00": 24}]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"timeout": -1},
+        {"timeout": float("nan")},
+        {"timeout": float("inf")},
+        {"poll_interval": 0},
+    ],
+)
+def test_wait_validates_before_query(quafu, kwargs):
+    job = fq.submit(fq.Circuit(2), target="quafu:Baihua", shots=1024)
+    with pytest.raises(ValueError):
+        job.wait(**kwargs)
+    assert quafu.gets == []
+
+
+def test_rejected_outputs_and_shots_never_submit(quafu):
+    with pytest.raises(CapabilityError):
+        fq.submit(
+            fq.Circuit(2),
+            target="quafu:Baihua",
+            shots=1024,
+            outputs=fq.expectation(fq.Z(0)),
+        )
+    with pytest.raises(ValueError):
+        fq.submit(fq.Circuit(2), target="quafu:Baihua", shots=12)
+    assert quafu.posts == []
+
+
+def test_no_retry_after_uncertain_submission(quafu, monkeypatch):
+    post = Mock(side_effect=TimeoutError("response lost"))
+    monkeypatch.setattr(quafu, "post_json", post)
+    with pytest.raises(TimeoutError):
+        fq.submit(fq.Circuit(2), target="quafu:Baihua", shots=1024)
+    assert post.call_count == 1
+
+
+def test_receipt_validation_precedes_network(quafu, tmp_path):
+    job = fq.submit(fq.Circuit(2), target="quafu:Baihua", shots=1024)
+    path = tmp_path / "receipt.json"
+    job.save(path)
+    valid = json.loads(path.read_text())
+    for field, value in [
+        ("schema", "future"),
+        ("target", "other:host"),
+        ("n_wires", True),
+        ("target_qubits", [1, 1]),
+        ("id", ""),
+    ]:
+        path.write_text(json.dumps({**valid, field: value}))
+        with pytest.raises(ValueError):
+            fq.restore_job(path)
+    assert quafu.gets == []
+    assert len(quafu.posts) == 1
+
+
+def test_jiuding_uses_managed_jobs_without_resubmission(monkeypatch, tmp_path):
+    from flagquantum.remote.compute.jiuding import JiudingClient
+
+    calls = []
+    state = ["Pending"]
+    expected = fq.run(fq.Circuit(1))
+
+    class Client(JiudingClient):
+        def __init__(self, *, workspace=None):
+            self.workspace_name = workspace
+
+        def submit_program(self, *args, **kwargs):
+            calls.append("submit")
+            return {"jobId": "compute-123"}
+
+        def restore_receipt(self, job_id):
+            calls.append("restore")
+            return {"jobId": job_id}
+
+        def status(self, receipt):
+            return [
+                {"id": "compute-123", "status": state[0]},
+                {"id": "previous-attempt", "status": "Failed"},
+            ]
+
+        def cancel(self, receipt):
+            calls.append("cancel")
+            state[0] = "Cancelled"
+
+    monkeypatch.setattr(jobs, "JiudingClient", Client)
+    monkeypatch.setattr(
+        "flagquantum.remote.compute._managed_program.read_managed_result",
+        lambda client, receipt: expected,
+    )
+    job = fq.submit(
+        fq.Circuit(1),
+        target="jiuding:cpu",
+        image="test-image",
+        workspace="test-workspace",
+    )
+    assert job.status() == "queued"
+    with pytest.raises(ExecutionError):
+        job.result()
+    path = tmp_path / "compute.json"
+    job.save(path)
+    restored = fq.restore_job(path)
+    state[0] = "Succeed"
+    assert restored.result() is expected
+    assert calls.count("submit") == 1
+    assert calls.count("restore") == 1
+    restored.cancel()
+    assert restored.status() == "cancelled"
+
+
+def test_jiuding_missing_image_fails_before_client(monkeypatch):
+    client = Mock(side_effect=AssertionError("must not connect"))
+    monkeypatch.setattr(jobs, "JiudingClient", client)
+    with pytest.raises(ValueError, match="requires image"):
+        fq.submit(fq.Circuit(1), target="jiuding:cpu")
+    client.assert_not_called()
+
+
+def test_wait_polls_without_resubmitting(quafu, monkeypatch):
+    job = fq.submit(fq.Circuit(2), target="quafu:Baihua", shots=1024)
+    sleeps = []
+
+    def finish(delay):
+        sleeps.append(delay)
+        quafu.state = "Finished"
+
+    monkeypatch.setattr(jobs.time, "sleep", finish)
+    assert job.wait(timeout=10, poll_interval=0.1).counts == [{"10": 1000, "00": 24}]
+    assert sleeps == [0.1]
+    assert len(quafu.posts) == 1
+
+
+def test_approved_job_state_and_receipt_contract(quafu, tmp_path):
+    from pathlib import Path
+    from typing import get_args
+
+    contract = json.loads(
+        (
+            Path(__file__).resolve().parents[2]
+            / "contracts/remote-jobs-v1-candidate.json"
+        ).read_text()
+    )
+    assert list(get_args(jobs.JobStatus)) == contract["statuses"]
+    job = fq.submit(fq.Circuit(2), target="quafu:Baihua", shots=1024)
+    path = tmp_path / "job.json"
+    job.save(path)
+    receipt = json.loads(path.read_text())
+    assert receipt["schema"] == contract["receipt_schema"]
+    assert receipt["submission_identity"]["deployment_artifact_sha256"]
+
+
+def test_wait_handles_delayed_quafu_result(quafu, monkeypatch):
+    job = fq.submit(fq.Circuit(2), target="quafu:Baihua", shots=1024)
+    quafu.state = "Finished"
+    original = quafu.get_json
+    result_reads = []
+
+    def delayed(url, headers, timeout):
+        if "/result/" in url:
+            result_reads.append(url)
+            if len(result_reads) == 1:
+                return {}
+        return original(url, headers, timeout)
+
+    monkeypatch.setattr(quafu, "get_json", delayed)
+    monkeypatch.setattr(jobs.time, "sleep", lambda delay: None)
+    assert job.wait(timeout=5).counts == [{"10": 1000, "00": 24}]
+    assert len(result_reads) == 2
+    assert len(quafu.posts) == 1

--- a/tests/api_contract/test_remote_jobs.py
+++ b/tests/api_contract/test_remote_jobs.py
@@ -151,24 +151,29 @@ def test_receipt_validation_precedes_network(quafu, tmp_path):
     assert len(quafu.posts) == 1
 
 
-def test_jiuding_uses_managed_jobs_without_resubmission(monkeypatch, tmp_path):
-    from flagquantum.remote.compute.jiuding import JiudingClient
+def test_jiuding_native_jobs_restore_without_resubmission(monkeypatch, tmp_path):
+    from flagquantum.remote.compute._native_job import NativeJiudingJobClient
 
     calls = []
     state = ["Pending"]
     expected = fq.run(fq.Circuit(1))
 
-    class Client(JiudingClient):
-        def __init__(self, *, workspace=None):
-            self.workspace_name = workspace
+    class Client(NativeJiudingJobClient):
+        def __init__(self, *, project, queue=None):
+            self.project = project
+            self.queue = queue
 
         def submit_program(self, *args, **kwargs):
             calls.append("submit")
-            return {"jobId": "compute-123"}
+            return {
+                "jobId": "compute-123",
+                "project": self.project,
+                "queue": self.queue,
+                "artifact_transport": "job_logs",
+            }
 
-        def restore_receipt(self, job_id):
-            calls.append("restore")
-            return {"jobId": job_id}
+        def read_result(self, receipt):
+            return expected
 
         def status(self, receipt):
             return [
@@ -180,16 +185,13 @@ def test_jiuding_uses_managed_jobs_without_resubmission(monkeypatch, tmp_path):
             calls.append("cancel")
             state[0] = "Cancelled"
 
-    monkeypatch.setattr(jobs, "JiudingClient", Client)
-    monkeypatch.setattr(
-        "flagquantum.remote.compute._managed_program.read_managed_result",
-        lambda client, receipt: expected,
-    )
+    monkeypatch.setattr(jobs, "NativeJiudingJobClient", Client)
     job = fq.submit(
         fq.Circuit(1),
         target="jiuding:cpu",
         image="test-image",
-        workspace="test-workspace",
+        project="test.project",
+        queue="test-queue",
     )
     assert job.status() == "queued"
     with pytest.raises(ExecutionError):
@@ -200,14 +202,14 @@ def test_jiuding_uses_managed_jobs_without_resubmission(monkeypatch, tmp_path):
     state[0] = "Succeed"
     assert restored.result() is expected
     assert calls.count("submit") == 1
-    assert calls.count("restore") == 1
+    assert calls == ["submit"]
     restored.cancel()
     assert restored.status() == "cancelled"
 
 
 def test_jiuding_missing_image_fails_before_client(monkeypatch):
     client = Mock(side_effect=AssertionError("must not connect"))
-    monkeypatch.setattr(jobs, "JiudingClient", client)
+    monkeypatch.setattr(jobs, "NativeJiudingJobClient", client)
     with pytest.raises(ValueError, match="requires image"):
         fq.submit(fq.Circuit(1), target="jiuding:cpu")
     client.assert_not_called()
@@ -264,3 +266,26 @@ def test_wait_handles_delayed_quafu_result(quafu, monkeypatch):
     assert job.wait(timeout=5).counts == [{"10": 1000, "00": 24}]
     assert len(result_reads) == 2
     assert len(quafu.posts) == 1
+
+
+@pytest.mark.parametrize(
+    "options, error, message",
+    [
+        ({}, ValueError, "requires project"),
+        ({"workspace": "old-workspace"}, TypeError, "project and queue"),
+        ({"project": "invalid"}, ValueError, "project-set.project"),
+    ],
+)
+def test_native_job_configuration_fails_before_network(
+    monkeypatch, options, error, message
+):
+    from flagquantum.remote.compute._native_job import NativeJiudingJobClient
+
+    monkeypatch.delenv("JIUDING_PROJECT", raising=False)
+    monkeypatch.setattr(
+        NativeJiudingJobClient,
+        "_request",
+        Mock(side_effect=AssertionError("must not connect")),
+    )
+    with pytest.raises(error, match=message):
+        fq.submit(fq.Circuit(1), target="jiuding:cpu", image="test-image", **options)

--- a/tests/team/remote/test_native_jobs.py
+++ b/tests/team/remote/test_native_jobs.py
@@ -1,0 +1,140 @@
+"""Native jobs carry circuits and checked results without a workspace transport."""
+
+import base64
+import hashlib
+import json
+import shlex
+import subprocess
+import sys
+
+import pytest
+
+import flagquantum as fq
+from flagquantum.remote.compute._native_job import (
+    NativeJiudingJobClient,
+    _command,
+    _decode_lines,
+)
+from flagquantum.remote.compute._workspace_executor import SCHEMA, VERSION
+
+
+def test_inline_command_executes_circuit_and_decodes_result():
+    ir = fq.Circuit(2).x(0).to_ir()
+    command = _command(
+        {
+            "schema": SCHEMA,
+            "version": VERSION,
+            "operation": "statevector",
+            "request_id": "batch-program",
+            "target": "jiuding:cpu",
+            "program": ir.to_dict(),
+        },
+        "test-run",
+    )
+    args = shlex.split(command)
+    args[0] = sys.executable
+    output = subprocess.run(
+        args, capture_output=True, text=True, timeout=45, check=True
+    )
+    result = _decode_lines(output.stdout.splitlines(), "test-run")
+    assert result["ok"] is True
+    from flagquantum.remote.compute._program_job import decode_program_result
+
+    decoded = decode_program_result(
+        result, requested_target="jiuding:cpu", selected_target="jiuding:cpu"
+    )
+    expected = fq.run(fq.Circuit(2).x(0))
+    import torch
+
+    torch.testing.assert_close(decoded.state, expected.state)
+
+
+def chunks(value):
+    data = json.dumps(value).encode()
+    digest = hashlib.sha256(data).hexdigest()
+    encoded = base64.b64encode(data).decode()
+    parts = [encoded[i : i + 100] for i in range(0, len(encoded), 100)]
+    return [
+        f"FQ_RESULT_run {i}/{len(parts)} {digest} {part}"
+        for i, part in enumerate(parts)
+    ]
+
+
+def test_result_chunks_reorder_deduplicate_and_ignore_other_runs():
+    value = {"message": "large result" * 50}
+    lines = chunks(value)
+    assert _decode_lines(["other output", *reversed(lines), lines[0]], "run") == value
+    with pytest.raises(RuntimeError, match="no result yet"):
+        _decode_lines(lines[:-1], "run")
+    with pytest.raises(RuntimeError, match="Conflicting"):
+        _decode_lines([*lines, lines[0] + "A"], "run")
+    damaged = lines.copy()
+    fields = damaged[0].split(" ")
+    fields[-1] = "A" + fields[-1][1:]
+    damaged[0] = " ".join(fields)
+    with pytest.raises(RuntimeError, match="digest"):
+        _decode_lines(damaged, "run")
+
+
+def test_transport_bounds_precede_execution():
+    with pytest.raises(ValueError, match="64 KiB"):
+        _command({"payload": "x" * 65536}, "run")
+    with pytest.raises(RuntimeError, match="bounds"):
+        _decode_lines(["FQ_RESULT_run 0/4097 digest a"], "run")
+    with pytest.raises(RuntimeError, match="Malformed"):
+        _decode_lines(["FQ_RESULT_run invalid"], "run")
+
+
+def test_project_context_uses_authenticated_user_and_queue(monkeypatch):
+    client = NativeJiudingJobClient(project="set.project", queue="queue")
+    monkeypatch.setattr(client, "_auth", lambda: {"AIRS-Token": "private"})
+    paths = []
+
+    def request(path, body, headers, **kwargs):
+        paths.append(path)
+        if path.endswith("userinfo"):
+            return {"data": {"id": "own-user", "alias": "user"}}
+        if path == "/api/v1/projsets/select-joined":
+            return {"items": [{"projsetInfo": {"name": "set", "id": "set-id"}}]}
+        if path == "/api/v1/projects/select-joined":
+            assert body == {"projsetId": "set-id"}
+            return {"items": [{"projInfo": {"name": "project", "id": "project-id"}}]}
+        raise AssertionError(path)
+
+    def pages(path, body, key, headers):
+        assert path == "/api/v1/queue/select"
+        assert body["as_user"] is True and body["userId"] == "own-user"
+        assert headers["x-user-id"] == "own-user"
+        return [
+            {
+                "name": "queue",
+                "id": "queue-id",
+                "status": "QUEUE_STATUS_ACTIVE",
+                "quotaInfoList": [
+                    {
+                        "clusterId": "cluster",
+                        "clusterName": "cluster",
+                        "zoneQuotaInfoList": [
+                            {
+                                "zoneId": "zone",
+                                "quotaMetaList": [
+                                    {
+                                        "priority": "high",
+                                        "resourceDetail": {"acceleratorModel": "A100"},
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(client, "_request", request)
+    monkeypatch.setattr(client, "_pages", pages)
+    context = client.workspace()
+    assert context["queueId"] == "queue-id"
+    assert context["storageInfo"] == []
+    assert all("workspaces" not in path for path in paths)
+    assert client.workspace() == context
+    assert len(paths) == 3

--- a/tests/unit/test_public_api_candidate.py
+++ b/tests/unit/test_public_api_candidate.py
@@ -18,6 +18,7 @@ EXECUTION_PLAN = ROOT / "contracts" / "execution-plan-v1-candidate.json"
 MODULE_TRAINING = ROOT / "contracts" / "module-training-v1-candidate.json"
 ERRORS_MODULE = ROOT / "contracts" / "errors-module-boundary-v1-candidate.json"
 EXTENSION_PROTOCOL = ROOT / "contracts" / "extension-protocol-v1-candidate.json"
+REMOTE_JOBS = ROOT / "contracts" / "remote-jobs-v1-candidate.json"
 OBSERVABLE_OUTPUTS = ROOT / "contracts" / "observable-outputs-v1-candidate.json"
 
 
@@ -82,6 +83,9 @@ def test_candidate_classifies_every_historical_stable_export_exactly_once() -> N
             authorized_additions.update(extension["additions"])
     observable_outputs = _load(OBSERVABLE_OUTPUTS)
     authorized_additions.update(observable_outputs["root_additions"])
+    jobs_contract = _load(REMOTE_JOBS)
+    if jobs_contract["implementation_authorized"] is True:
+        authorized_additions.update(jobs_contract["root_additions"])
     authorized_additions.update(candidate.get("approved_namespace_additions", ()))
     assert set(classified) == set(exports) | authorized_additions
 
@@ -168,7 +172,11 @@ def test_candidate_stable_core_stays_within_reviewed_root_budget() -> None:
 
     final_core = set(stable_core["retain"]) | set(stable_core["planned_additions"])
 
-    assert len(final_core) == 31
+    jobs_contract = _load(REMOTE_JOBS)
+    assert jobs_contract["implementation_authorized"] is True
+    assert set(jobs_contract["root_additions"]) == {"submit", "restore_job"}
+    assert set(jobs_contract["root_additions"]) <= final_core
+    assert len(final_core) == 33
     assert len(final_core) <= rules["root_export_budget"]
     assert {"Circuit", "Module", "ExecutionOptions", "ExecutionPlan"} <= final_core
     assert {"plan", "run", "train", "ExecutionResult", "TrainingResult"} <= final_core

--- a/tests/unit/test_public_api_snapshot.py
+++ b/tests/unit/test_public_api_snapshot.py
@@ -48,6 +48,11 @@ def test_baseline_covers_current_stable_export_manifest() -> None:
     ):
         authorized_additions.update(extensions["root_additions"])
     authorized_additions.update(observable_outputs["root_additions"])
+    jobs_contract = json.loads(
+        (ROOT / "contracts/remote-jobs-v1-candidate.json").read_text()
+    )
+    if jobs_contract["implementation_authorized"] is True:
+        authorized_additions.update(jobs_contract["root_additions"])
 
     assert (
         set(manifest["stable_exports"])

--- a/tools/public_api_snapshot.py
+++ b/tools/public_api_snapshot.py
@@ -194,6 +194,9 @@ def validate() -> tuple[str, ...]:
     observable_outputs_contract = json.loads(
         OBSERVABLE_OUTPUTS_CONTRACT.read_text(encoding="utf-8")
     )
+    jobs_contract = json.loads(
+        (ROOT / "contracts/remote-jobs-v1-candidate.json").read_text()
+    )
     actual = generate()
     names = actual["stable_exports"]
     assert isinstance(names, list)
@@ -236,6 +239,8 @@ def validate() -> tuple[str, ...]:
         )
     authorized_changes.update(observable_outputs_contract.get("root_additions", ()))
     authorized_changes.update(observable_outputs_contract.get("root_removals", ()))
+    if jobs_contract.get("implementation_authorized") is True:
+        authorized_changes.update(jobs_contract["root_additions"])
     missing = sorted(set(names) - set(historical_exports) - authorized_changes)
     if missing:
         return (
@@ -300,6 +305,20 @@ def validate() -> tuple[str, ...]:
         errors.extend(
             _validate_authorized_extension_protocol(extension_protocol_contract)
         )
+    if jobs_contract.get("implementation_authorized") is True:
+        from flagquantum.remote import jobs
+
+        for name, expected_signature in jobs_contract["public_signatures"].items():
+            obj = jobs
+            for component in name.split("."):
+                obj = getattr(obj, component)
+            if str(inspect.signature(obj)) != expected_signature:
+                errors.append(f"authorized remote job API signature changed: {name}")
+        import flagquantum as fq
+
+        for name in jobs_contract["root_additions"]:
+            if name not in names or name not in fq.__all__:
+                errors.append(f"authorized remote job root API missing: {name}")
     return tuple(errors)
 
 


### PR DESCRIPTION
## Change

Add resumable remote jobs for Quafu and Jiuding. `fq.submit()` returns after provider acknowledgement; `status()` queries once, `result()` retrieves a completed result, and `wait()` explicitly polls with a deadline. `save()` and `fq.restore_job()` reconnect after a notebook or process restart without resubmitting. Cancellation is explicit, and timeouts leave the remote task running.

Quafu supports full-register counts with service-side or explicit local compilation. Jiuding uses native HTTP jobs with project, queue and image selection, without SSH, a workspace pod or source uploads. Its image-installed executor consumes an inline circuit and returns checked, chunked results through authenticated job logs. Existing synchronous `fq.run()` behavior is preserved.

## Usage

Requires this development branch. Configure `QUAFU_API_TOKEN` for Quafu, or `JIUDING_AK` and `JIUDING_SK` for Jiuding; do not put credentials in notebooks or receipts.

### Submit once

```python
import flagquantum as fq

program = fq.Circuit(2).x(0)

# Quafu hardware; compiler omitted to use service-side compilation.
quafu_job = fq.submit(
    program,
    target="quafu:Baihua",
    outputs=fq.counts(),
    shots=1024,
)
quafu_job.save("quafu-job.json")
print(quafu_job.id)

# Jiuding GPU simulation; no SSH or development workspace required.
jiuding_job = fq.submit(
    program,
    target="jiuding:gpu",
    project="YOUR_PROJECT_SET.YOUR_PROJECT",
    queue="YOUR_QUEUE",
    image="YOUR_FLAGQUANTUM_RUNTIME_IMAGE",
    outputs=fq.counts(),
    shots=1024,
)
jiuding_job.save("jiuding-job.json")
print(jiuding_job.id)
```

Run either provider block as needed. Jiuding placeholders must identify a project, queue and compatible image accessible to your account. `submit()` waits for preparation and acknowledgement, not execution completion. Saving never overwrites an existing receipt.

### Check or resume in a later notebook cell / process

```python
import flagquantum as fq

job = fq.restore_job("quafu-job.json")  # Or "jiuding-job.json".
state = job.status()                   # One query; no background polling.
print(state, job.raw_status)
if state == "succeeded":
    print(job.result().counts)

# Alternatively, explicitly wait for completion and result availability:
result = job.wait(timeout=600, poll_interval=3)
print(result.counts)

# To stop unfinished work, call job.cancel(), then query status to confirm.
```

Restoration does not resubmit. A wait timeout leaves the remote job running. Provider results may become readable shortly after the status changes to success; `wait()` handles that delay within its deadline.

## Recorded live results

Both checks used **two qubits, X(0), 1,024 shots**, with logical wire ordering. The ideal output is `10`.

| Execution | Retrieved `result.counts` | What was verified |
| --- | --- | --- |
| Quafu Baihua hardware | `[{"10": 938, "00": 71, "11": 15}]` | Service compilation, hardware task completion and separate-process restoration |
| Jiuding A100 GPU simulation | `[{"10": 1024}]` | Native HTTP job, `cuda:0`, no CPU fallback, separate-process restoration without SSH/workspace access or resubmission |

These are measured results, not promised outputs for every run. Quafu's observed target-outcome fraction was 938/1024 (91.6%); this single circuit does not establish device fidelity. The Jiuding result is simulation on a GPU, not QPU hardware execution. Neither check establishes performance or scalability.

Evidence: [Quafu record](https://github.com/FlagQuantum/FlagQuantum-dev/blob/feat/remote-job-lifecycle/docs/development/evidence/remote_jobs_quafu_20260911.json), [Jiuding record](https://github.com/FlagQuantum/FlagQuantum-dev/blob/feat/remote-job-lifecycle/docs/development/evidence/remote_jobs_jiuding_20260911.json). Full usage and limits: [remote jobs guide](https://github.com/FlagQuantum/FlagQuantum-dev/blob/feat/remote-job-lifecycle/docs/guides/REMOTE_JOBS.md).

## Boundaries

- This is a development API, not included in PyPI 0.2.0. The owner-approved API proposal and candidate contract are included.
- Jiuding commands are limited to 64 KiB and serialized results to 8 MiB; retrieval depends on platform log retention and permissions. The adapter requires one high-priority resource configuration and a compatible private image.
- Quafu grouped expectations remain synchronous. No automatic resubmission, background watcher or multi-GPU job support is introduced.
- Receipts contain identity and decoding context, not credentials, and are saved with owner-only access.

## Validation

- Local API contract and Remote suites: 246 passed, 1 skipped after rebasing onto current main.
- API baseline, architecture boundaries, documentation consistency, repository hygiene, Ruff and focused mypy checks passed during implementation.
- Live Quafu counts job: submitted and restored in a separate process, preserving logical bit ordering.
- Live native Jiuding job: one A100, two-qubit X(0), 1,024 shots, exact `10: 1024`; separate-process restoration succeeded with SSH, workspace access and resubmission explicitly forbidden in the verification process.
- Sanitized live evidence is in `docs/development/evidence/remote_jobs_{quafu,jiuding}_20260911.json`. These small correctness checks are not performance or scalability claims. PR CI is reported separately by GitHub.

